### PR TITLE
Fix streaming distance calculation for PQ and add unit test

### DIFF
--- a/rs/quantization/benches/pq_dist.rs
+++ b/rs/quantization/benches/pq_dist.rs
@@ -7,9 +7,9 @@ use utils::test_utils::generate_random_vector;
 fn bench_pq_distance(c: &mut Criterion) {
     env_logger::init();
     let mut group = c.benchmark_group("PQ Distance");
-    for dimension in [128].iter() {
-        for subvector_dimension in [4].iter() {
-            for num_bits in [4].iter() {
+    for dimension in [128, 256].iter() {
+        for subvector_dimension in [4, 8, 16, 32, 64, 128].iter() {
+            for num_bits in [4, 8, 16].iter() {
                 let mut pqb = ProductQuantizerBuilder::new(
                     ProductQuantizerConfig {
                         dimension: *dimension,

--- a/rs/quantization/src/pq.rs
+++ b/rs/quantization/src/pq.rs
@@ -282,11 +282,10 @@ impl Quantizer for ProductQuantizer {
                 .sum::<f32>()
                 .sqrt()
         } else {
-            let _ = a
-                .iter()
+            a.iter()
                 .zip(b.iter())
                 .enumerate()
-                .map(|(subvector_idx, quantized_values)| {
+                .for_each(|(subvector_idx, quantized_values)| {
                     let a_quantized_value = quantized_values.0;
                     let b_quantized_value = quantized_values.1;
 


### PR DESCRIPTION
Turns out the streaming distance calculation was not doing any useful work (DCE'd maybe?). Fix it and add unit test.

Updated bm numbers:
```
PQ Distance/pq_distance_128_4_4/Scalar
                        time:   [99.631 ns 99.922 ns 100.25 ns]
PQ Distance/pq_distance_128_4_4/SIMD
                        time:   [116.51 ns 116.85 ns 117.27 ns]
PQ Distance/pq_distance_128_4_4/StreamSIMD
                        time:   [85.223 ns 85.434 ns 85.661 ns]
PQ Distance/pq_distance_128_4_8/Scalar
                        time:   [104.21 ns 104.43 ns 104.68 ns]
PQ Distance/pq_distance_128_4_8/SIMD
                        time:   [116.53 ns 116.80 ns 117.14 ns]
PQ Distance/pq_distance_128_4_8/StreamSIMD
                        time:   [84.768 ns 84.880 ns 85.001 ns]
PQ Distance/pq_distance_128_4_16/Scalar
                        time:   [104.30 ns 104.42 ns 104.56 ns]
PQ Distance/pq_distance_128_4_16/SIMD
                        time:   [117.33 ns 117.56 ns 117.81 ns]
PQ Distance/pq_distance_128_4_16/StreamSIMD
                        time:   [84.835 ns 85.237 ns 85.743 ns]
PQ Distance/pq_distance_128_8_4/Scalar
                        time:   [70.106 ns 70.697 ns 71.412 ns]
PQ Distance/pq_distance_128_8_4/SIMD
                        time:   [64.987 ns 65.148 ns 65.328 ns]
PQ Distance/pq_distance_128_8_4/StreamSIMD
                        time:   [50.838 ns 50.915 ns 50.999 ns]
PQ Distance/pq_distance_128_8_8/Scalar
                        time:   [68.997 ns 69.120 ns 69.254 ns]
PQ Distance/pq_distance_128_8_8/SIMD
                        time:   [64.948 ns 65.190 ns 65.535 ns]
PQ Distance/pq_distance_128_8_8/StreamSIMD
                        time:   [50.635 ns 50.680 ns 50.717 ns]
PQ Distance/pq_distance_128_8_16/Scalar
                        time:   [70.460 ns 71.102 ns 72.015 ns]
PQ Distance/pq_distance_128_8_16/SIMD
                        time:   [69.179 ns 69.390 ns 69.605 ns]
PQ Distance/pq_distance_128_8_16/StreamSIMD
                        time:   [52.207 ns 52.274 ns 52.341 ns]
PQ Distance/pq_distance_128_16_4/Scalar
                        time:   [29.458 ns 29.529 ns 29.611 ns]
PQ Distance/pq_distance_128_16_4/SIMD
                        time:   [42.483 ns 42.626 ns 42.804 ns]
PQ Distance/pq_distance_128_16_4/StreamSIMD
                        time:   [33.953 ns 34.079 ns 34.229 ns]
PQ Distance/pq_distance_128_16_8/Scalar
                        time:   [29.603 ns 29.669 ns 29.747 ns]
PQ Distance/pq_distance_128_16_8/SIMD
                        time:   [42.625 ns 42.734 ns 42.851 ns]
PQ Distance/pq_distance_128_16_8/StreamSIMD
                        time:   [33.554 ns 33.578 ns 33.606 ns]
PQ Distance/pq_distance_128_16_16/Scalar
                        time:   [31.477 ns 31.575 ns 31.679 ns]
PQ Distance/pq_distance_128_16_16/SIMD
                        time:   [44.310 ns 44.421 ns 44.548 ns]
PQ Distance/pq_distance_128_16_16/StreamSIMD
                        time:   [34.808 ns 34.949 ns 35.202 ns]
PQ Distance/pq_distance_128_32_4/Scalar
                        time:   [31.768 ns 31.820 ns 31.907 ns]
PQ Distance/pq_distance_128_32_4/SIMD
                        time:   [28.836 ns 28.861 ns 28.895 ns]
PQ Distance/pq_distance_128_32_4/StreamSIMD
                        time:   [24.989 ns 25.008 ns 25.030 ns]
PQ Distance/pq_distance_128_32_8/Scalar
                        time:   [31.795 ns 31.834 ns 31.889 ns]
PQ Distance/pq_distance_128_32_8/SIMD
                        time:   [29.449 ns 29.552 ns 29.730 ns]
PQ Distance/pq_distance_128_32_8/StreamSIMD
                        time:   [24.881 ns 24.906 ns 24.935 ns]
PQ Distance/pq_distance_128_32_16/Scalar
                        time:   [31.957 ns 32.018 ns 32.088 ns]
PQ Distance/pq_distance_128_32_16/SIMD
                        time:   [29.597 ns 29.635 ns 29.681 ns]
PQ Distance/pq_distance_128_32_16/StreamSIMD
                        time:   [24.991 ns 25.070 ns 25.157 ns]
PQ Distance/pq_distance_128_64_4/Scalar
                        time:   [40.666 ns 41.291 ns 42.215 ns]
PQ Distance/pq_distance_128_64_4/SIMD
                        time:   [23.470 ns 23.538 ns 23.621 ns]
PQ Distance/pq_distance_128_64_4/StreamSIMD
                        time:   [20.489 ns 20.516 ns 20.548 ns]
PQ Distance/pq_distance_128_64_8/Scalar
                        time:   [40.472 ns 40.499 ns 40.524 ns]
PQ Distance/pq_distance_128_64_8/SIMD
                        time:   [23.298 ns 23.409 ns 23.638 ns]
PQ Distance/pq_distance_128_64_8/StreamSIMD
                        time:   [20.557 ns 20.605 ns 20.657 ns]
PQ Distance/pq_distance_128_64_16/Scalar
                        time:   [40.603 ns 40.646 ns 40.693 ns]
PQ Distance/pq_distance_128_64_16/SIMD
                        time:   [23.340 ns 23.374 ns 23.422 ns]
PQ Distance/pq_distance_128_64_16/StreamSIMD
                        time:   [20.486 ns 20.506 ns 20.530 ns]
PQ Distance/pq_distance_128_128_4/Scalar
                        time:   [55.400 ns 55.488 ns 55.564 ns]
PQ Distance/pq_distance_128_128_4/SIMD
                        time:   [20.834 ns 20.913 ns 21.022 ns]
PQ Distance/pq_distance_128_128_4/StreamSIMD
                        time:   [18.014 ns 18.042 ns 18.074 ns]
PQ Distance/pq_distance_128_128_8/Scalar
                        time:   [53.322 ns 53.525 ns 53.749 ns]
PQ Distance/pq_distance_128_128_8/SIMD
                        time:   [20.817 ns 20.842 ns 20.871 ns]
PQ Distance/pq_distance_128_128_8/StreamSIMD
                        time:   [18.181 ns 18.237 ns 18.304 ns]
PQ Distance/pq_distance_128_128_16/Scalar
                        time:   [55.617 ns 55.710 ns 55.874 ns]
PQ Distance/pq_distance_128_128_16/SIMD
                        time:   [20.839 ns 20.966 ns 21.139 ns]
PQ Distance/pq_distance_128_128_16/StreamSIMD
                        time:   [18.133 ns 18.178 ns 18.225 ns]
PQ Distance/pq_distance_256_4_4/Scalar
                        time:   [203.02 ns 203.28 ns 203.58 ns]
PQ Distance/pq_distance_256_4_4/SIMD
                        time:   [226.84 ns 227.17 ns 227.62 ns]
PQ Distance/pq_distance_256_4_4/StreamSIMD
                        time:   [161.96 ns 162.33 ns 162.75 ns]
PQ Distance/pq_distance_256_4_8/Scalar
                        time:   [203.31 ns 204.00 ns 204.96 ns]
PQ Distance/pq_distance_256_4_8/SIMD
                        time:   [227.51 ns 228.09 ns 228.74 ns]
PQ Distance/pq_distance_256_4_8/StreamSIMD
                        time:   [162.56 ns 163.10 ns 163.63 ns]
PQ Distance/pq_distance_256_4_16/Scalar
                        time:   [210.35 ns 210.88 ns 211.60 ns]
PQ Distance/pq_distance_256_4_16/SIMD
                        time:   [260.45 ns 260.89 ns 261.41 ns]
PQ Distance/pq_distance_256_4_16/StreamSIMD
                        time:   [179.20 ns 179.53 ns 179.89 ns]
PQ Distance/pq_distance_256_8_4/Scalar
                        time:   [133.80 ns 133.99 ns 134.23 ns]
PQ Distance/pq_distance_256_8_4/SIMD
                        time:   [127.19 ns 127.51 ns 127.85 ns]
PQ Distance/pq_distance_256_8_4/StreamSIMD
                        time:   [100.73 ns 100.81 ns 100.91 ns]
PQ Distance/pq_distance_256_8_8/Scalar
                        time:   [134.56 ns 135.32 ns 136.14 ns]
PQ Distance/pq_distance_256_8_8/SIMD
                        time:   [126.18 ns 126.33 ns 126.53 ns]
PQ Distance/pq_distance_256_8_8/StreamSIMD
                        time:   [100.68 ns 100.80 ns 100.94 ns]
PQ Distance/pq_distance_256_8_16/Scalar
                        time:   [169.83 ns 170.11 ns 170.50 ns]
PQ Distance/pq_distance_256_8_16/SIMD
                        time:   [158.67 ns 159.00 ns 159.33 ns]
PQ Distance/pq_distance_256_8_16/StreamSIMD
                        time:   [112.63 ns 112.76 ns 112.93 ns]
PQ Distance/pq_distance_256_16_4/Scalar
                        time:   [56.445 ns 56.494 ns 56.539 ns]
PQ Distance/pq_distance_256_16_4/SIMD
                        time:   [79.278 ns 79.329 ns 79.387 ns]
PQ Distance/pq_distance_256_16_4/StreamSIMD
                        time:   [64.322 ns 64.380 ns 64.439 ns]
PQ Distance/pq_distance_256_16_8/Scalar
                        time:   [55.542 ns 55.635 ns 55.726 ns]
PQ Distance/pq_distance_256_16_8/SIMD
                        time:   [78.833 ns 78.880 ns 78.934 ns]
PQ Distance/pq_distance_256_16_8/StreamSIMD
                        time:   [64.380 ns 64.428 ns 64.479 ns]
PQ Distance/pq_distance_256_16_16/Scalar
                        time:   [83.488 ns 83.941 ns 84.399 ns]
PQ Distance/pq_distance_256_16_16/SIMD
                        time:   [97.759 ns 98.032 ns 98.390 ns]
PQ Distance/pq_distance_256_16_16/StreamSIMD
                        time:   [74.766 ns 74.860 ns 74.965 ns]
PQ Distance/pq_distance_256_32_4/Scalar
                        time:   [59.073 ns 59.213 ns 59.352 ns]
PQ Distance/pq_distance_256_32_4/SIMD
                        time:   [54.473 ns 54.498 ns 54.524 ns]
PQ Distance/pq_distance_256_32_4/StreamSIMD
                        time:   [45.913 ns 45.935 ns 45.959 ns]
PQ Distance/pq_distance_256_32_8/Scalar
                        time:   [57.993 ns 58.055 ns 58.122 ns]
PQ Distance/pq_distance_256_32_8/SIMD
                        time:   [54.911 ns 54.941 ns 54.978 ns]
PQ Distance/pq_distance_256_32_8/StreamSIMD
                        time:   [45.999 ns 46.031 ns 46.065 ns]
PQ Distance/pq_distance_256_32_16/Scalar
                        time:   [64.067 ns 64.228 ns 64.481 ns]
PQ Distance/pq_distance_256_32_16/SIMD
                        time:   [56.269 ns 56.312 ns 56.363 ns]
PQ Distance/pq_distance_256_32_16/StreamSIMD
                        time:   [48.456 ns 48.499 ns 48.549 ns]
PQ Distance/pq_distance_256_64_4/Scalar
                        time:   [74.143 ns 74.541 ns 75.007 ns]
PQ Distance/pq_distance_256_64_4/SIMD
                        time:   [46.137 ns 46.320 ns 46.570 ns]
PQ Distance/pq_distance_256_64_4/StreamSIMD
                        time:   [39.021 ns 39.071 ns 39.125 ns]
PQ Distance/pq_distance_256_64_8/Scalar
                        time:   [73.394 ns 73.557 ns 73.738 ns]
PQ Distance/pq_distance_256_64_8/SIMD
                        time:   [45.991 ns 46.124 ns 46.291 ns]
PQ Distance/pq_distance_256_64_8/StreamSIMD
                        time:   [39.096 ns 39.188 ns 39.287 ns]
PQ Distance/pq_distance_256_64_16/Scalar
                        time:   [78.654 ns 78.788 ns 78.964 ns]
PQ Distance/pq_distance_256_64_16/SIMD
                        time:   [46.212 ns 46.366 ns 46.544 ns]
PQ Distance/pq_distance_256_64_16/StreamSIMD
                        time:   [39.074 ns 39.168 ns 39.294 ns]
PQ Distance/pq_distance_256_128_4/Scalar
                        time:   [98.809 ns 99.031 ns 99.293 ns]
PQ Distance/pq_distance_256_128_4/SIMD
                        time:   [38.951 ns 39.008 ns 39.072 ns]
PQ Distance/pq_distance_256_128_4/StreamSIMD
                        time:   [35.136 ns 35.207 ns 35.284 ns]
PQ Distance/pq_distance_256_128_8/Scalar
                        time:   [99.800 ns 100.42 ns 101.04 ns]
PQ Distance/pq_distance_256_128_8/SIMD
                        time:   [40.224 ns 40.313 ns 40.406 ns]
PQ Distance/pq_distance_256_128_8/StreamSIMD
                        time:   [35.120 ns 35.221 ns 35.351 ns]
PQ Distance/pq_distance_256_128_16/Scalar
                        time:   [105.71 ns 105.90 ns 106.13 ns]
PQ Distance/pq_distance_256_128_16/SIMD
                        time:   [40.262 ns 40.548 ns 41.070 ns]
PQ Distance/pq_distance_256_128_16/StreamSIMD
                        time:   [34.976 ns 35.022 ns 35.098 ns]
```

For \*\_16\_\* cases, scalar seems to be a better choice than streaming. Not sure why though