### PR TITLE
Benchmark L2 distance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,6 +1391,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_yaml",
+ "strum",
  "tempdir",
  "utils",
 ]
@@ -1665,6 +1666,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.79",
+]
 
 [[package]]
 name = "syn"
@@ -1975,6 +1998,7 @@ dependencies = [
  "hdf5-metno",
  "ndarray",
  "rand 0.8.5",
+ "strum",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,6 +1995,7 @@ name = "utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "criterion",
  "hdf5-metno",
  "ndarray",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,4 @@ memmap2 = "0.9.5"
 byteorder = "1.5.0"
 num-traits = "0.2.19"
 ndarray = "0.15.6"
+strum = { version = "0.25.0", features = ["derive"] }

--- a/rs/index/src/hnsw/builder.rs
+++ b/rs/index/src/hnsw/builder.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, Context};
 use ordered_float::NotNan;
 use quantization::quantization::Quantizer;
 use rand::Rng;
+use utils::l2::L2DistanceCalculatorImpl::StreamingWithSIMD;
 
 use super::utils::{GraphTraversal, PointAndDistance, SearchContext};
 
@@ -257,7 +258,8 @@ impl HnswBuilder {
     fn distance_two_points(&self, a: u32, b: u32) -> f32 {
         let a_vector = self.get_vector(a);
         let b_vector = self.get_vector(b);
-        self.quantizer.distance(a_vector, b_vector, 2)
+        self.quantizer
+            .distance(a_vector, b_vector, StreamingWithSIMD)
     }
 
     fn get_vector(&self, point_id: u32) -> &[u8] {
@@ -355,7 +357,8 @@ impl HnswBuilder {
 
 impl GraphTraversal for HnswBuilder {
     fn distance(&self, query: &[u8], point_id: u32) -> f32 {
-        self.quantizer.distance(query, self.get_vector(point_id), 2)
+        self.quantizer
+            .distance(query, self.get_vector(point_id), StreamingWithSIMD)
     }
 
     fn get_edges_for_point(&self, point_id: u32, layer: u8) -> Option<Vec<u32>> {

--- a/rs/index/src/hnsw/index.rs
+++ b/rs/index/src/hnsw/index.rs
@@ -179,7 +179,11 @@ impl Hnsw {
 
 impl GraphTraversal for Hnsw {
     fn distance(&self, query: &[u8], point_id: u32) -> f32 {
-        self.quantizer.distance(query, self.get_vector(point_id), 2)
+        self.quantizer.distance(
+            query,
+            self.get_vector(point_id),
+            utils::l2::L2DistanceCalculatorImpl::StreamingWithSIMD,
+        )
     }
 
     fn get_edges_for_point(&self, point_id: u32, layer: u8) -> Option<Vec<u32>> {

--- a/rs/quantization/Cargo.toml
+++ b/rs/quantization/Cargo.toml
@@ -13,6 +13,7 @@ utils.workspace = true
 criterion.workspace = true
 log.workspace = true
 env_logger.workspace = true
+strum.workspace = true
 
 [[bench]]
 name = "pq_dist"

--- a/rs/quantization/src/pq_builder.rs
+++ b/rs/quantization/src/pq_builder.rs
@@ -1,5 +1,6 @@
 use kmeans::*;
 use log::debug;
+use utils::l2::L2DistanceCalculatorImpl::{Scalar, StreamingWithSIMD, SIMD};
 
 use crate::pq::{ProductQuantizer, ProductQuantizerConfig};
 use crate::quantization::Quantizer;
@@ -152,9 +153,9 @@ mod tests {
         let pq = pqb.build().unwrap();
         let point = pq.quantize(&generate_random_vector(DIMENSION));
         let query = pq.quantize(&generate_random_vector(DIMENSION));
-        let dist_scalar = pq.distance(&query, &point, 0);
-        let dist_simd = pq.distance(&query, &point, 1);
-        let dist_stream = pq.distance(&query, &point, 2);
+        let dist_scalar = pq.distance(&query, &point, Scalar);
+        let dist_simd = pq.distance(&query, &point, SIMD);
+        let dist_stream = pq.distance(&query, &point, StreamingWithSIMD);
 
         let epsilon = 1e-5;
         assert!((dist_simd - dist_scalar).abs() < epsilon);

--- a/rs/quantization/src/quantization.rs
+++ b/rs/quantization/src/quantization.rs
@@ -1,3 +1,4 @@
+use utils::l2::L2DistanceCalculatorImpl;
 pub trait Quantizer {
     /// Quantize a vector
     fn quantize(&self, value: &[f32]) -> Vec<u8>;
@@ -9,5 +10,5 @@ pub trait Quantizer {
     fn original_vector(&self, quantized_vector: &[u8]) -> Vec<f32>;
 
     /// Compute the distance between two quantized points
-    fn distance(&self, query: &[u8], point: &[u8], mode: u8) -> f32;
+    fn distance(&self, query: &[u8], point: &[u8], implem: L2DistanceCalculatorImpl) -> f32;
 }

--- a/rs/utils/Cargo.toml
+++ b/rs/utils/Cargo.toml
@@ -8,3 +8,4 @@ anyhow = "1.0.90"
 hdf5.workspace = true
 ndarray.workspace = true
 rand.workspace = true
+strum.workspace = true

--- a/rs/utils/Cargo.toml
+++ b/rs/utils/Cargo.toml
@@ -9,3 +9,8 @@ hdf5.workspace = true
 ndarray.workspace = true
 rand.workspace = true
 strum.workspace = true
+criterion.workspace = true
+
+[[bench]]
+name = "l2"
+harness = false

--- a/rs/utils/benches/l2.rs
+++ b/rs/utils/benches/l2.rs
@@ -1,0 +1,32 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use utils::l2::L2DistanceCalculator;
+use utils::test_utils::generate_random_vector;
+
+fn bench_l2_distance(c: &mut Criterion) {
+    let mut group = c.benchmark_group("L2 Distance");
+    let mut distance_calculator = L2DistanceCalculator::new();
+    for size in [
+        16, 32, 64, 128, 256, 512, 1024, 2048, 4096,
+        384,  // VECTOR_DIM_SENTENCE_TRANSFORMERS_MINI_LM
+        768,  // VECTOR_DIM_SENTENCE_TRANSFORMERS_MPNET
+        1536, // VECTOR_DIM_OPENAI_SMALL
+        3072, // VECTOR_DIM_OPENAI_LARGE
+    ]
+    .iter()
+    {
+        let a = generate_random_vector(*size);
+        let b = generate_random_vector(*size);
+
+        group.bench_with_input(BenchmarkId::new("Scalar", *size), &size, |bencher, _| {
+            bencher.iter(|| distance_calculator.calculate_scalar(black_box(&a), black_box(&b)))
+        });
+
+        group.bench_with_input(BenchmarkId::new("SIMD", *size), &size, |bencher, _| {
+            bencher.iter(|| distance_calculator.calculate_simd(black_box(&a), black_box(&b)))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_l2_distance);
+criterion_main!(benches);

--- a/rs/utils/src/l2.rs
+++ b/rs/utils/src/l2.rs
@@ -2,7 +2,16 @@ use std::ops::Mul;
 use std::simd::num::SimdFloat;
 use std::simd::{f32x4, f32x8};
 
+use strum::EnumIter;
+
 use crate::{DistanceCalculator, StreamingDistanceCalculator};
+
+#[derive(Debug, EnumIter, PartialEq, Clone)]
+pub enum L2DistanceCalculatorImpl {
+    Scalar,
+    SIMD,
+    StreamingWithSIMD,
+}
 
 pub struct L2DistanceCalculator {
     dist_simd_8: f32x8,


### PR DESCRIPTION
For completeness
```
L2 Distance/Scalar/16   time:   [3.0676 ns 3.0785 ns 3.0906 ns]
L2 Distance/SIMD/16     time:   [4.5063 ns 4.5171 ns 4.5291 ns]
L2 Distance/Scalar/32   time:   [7.1169 ns 7.1357 ns 7.1607 ns]
L2 Distance/SIMD/32     time:   [6.0645 ns 6.0703 ns 6.0762 ns]
L2 Distance/Scalar/64   time:   [17.253 ns 17.268 ns 17.287 ns]
L2 Distance/SIMD/64     time:   [9.6623 ns 9.6706 ns 9.6802 ns]
L2 Distance/Scalar/128  time:   [46.546 ns 46.596 ns 46.662 ns]
L2 Distance/SIMD/128    time:   [17.162 ns 17.172 ns 17.187 ns]
L2 Distance/Scalar/256  time:   [104.90 ns 105.01 ns 105.15 ns]
L2 Distance/SIMD/256    time:   [33.034 ns 33.049 ns 33.064 ns]
L2 Distance/Scalar/512  time:   [267.97 ns 268.22 ns 268.53 ns]
L2 Distance/SIMD/512    time:   [58.694 ns 58.737 ns 58.791 ns]
L2 Distance/Scalar/1024 time:   [618.16 ns 619.51 ns 621.37 ns]
L2 Distance/SIMD/1024   time:   [110.58 ns 110.87 ns 111.44 ns]
L2 Distance/Scalar/2048 time:   [1.3176 µs 1.3189 µs 1.3204 µs]
L2 Distance/SIMD/2048   time:   [212.38 ns 212.72 ns 213.26 ns]
L2 Distance/Scalar/4096 time:   [2.7153 µs 2.7175 µs 2.7200 µs]
L2 Distance/SIMD/4096   time:   [416.46 ns 417.31 ns 418.57 ns]
L2 Distance/Scalar/384  time:   [182.31 ns 197.45 ns 229.59 ns]
L2 Distance/SIMD/384    time:   [46.385 ns 46.500 ns 46.635 ns]
L2 Distance/Scalar/768  time:   [446.12 ns 447.15 ns 448.39 ns]
L2 Distance/SIMD/768    time:   [84.599 ns 84.754 ns 84.947 ns]
L2 Distance/Scalar/1536 time:   [972.20 ns 974.02 ns 976.03 ns]
L2 Distance/SIMD/1536   time:   [161.91 ns 162.37 ns 162.97 ns]
L2 Distance/Scalar/3072 time:   [2.0277 µs 2.0340 µs 2.0415 µs]
L2 Distance/SIMD/3072   time:   [315.49 ns 315.93 ns 316.41 ns]
```