### PR TITLE
index_writer binary to build an index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,8 +850,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
+ "env_logger",
  "hdf5-metno",
+ "index",
+ "log",
  "ndarray",
+ "quantization",
+ "tempdir",
 ]
 
 [[package]]
@@ -1384,6 +1389,7 @@ dependencies = [
 name = "quantization"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "criterion",
  "env_logger",
  "kmeans",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ criterion = "0.4"
 proto = {path='./rs/proto'}
 quantization = {path='./rs/quantization'}
 utils = {path='./rs/utils'}
+index = {path='./rs/index'}
 tonic = "0.8"
 prost = "0.11"
 tonic-build = "0.8"

--- a/rs/index/src/hnsw/builder.rs
+++ b/rs/index/src/hnsw/builder.rs
@@ -444,7 +444,6 @@ mod tests {
                 1,
                 codebook,
                 base_directory.clone(),
-                "test_codebook".to_string(),
             )),
             ef_contruction: 0,
             entry_point: vec![0, 1],
@@ -556,7 +555,6 @@ mod tests {
             num_bits,
             codebook,
             base_directory.clone(),
-            "test_codebook".to_string(),
         );
 
         let mut builder = HnswBuilder::new(5, 10, 20, Box::new(pq));

--- a/rs/index/src/hnsw/reader.rs
+++ b/rs/index/src/hnsw/reader.rs
@@ -103,8 +103,6 @@ mod tests {
             dimension: 128,
             subvector_dimension: 8,
             num_bits: 8,
-            base_directory: base_directory.clone(),
-            codebook_name: "codebook".to_string(),
         };
 
         let pq_builder_config = ProductQuantizerBuilderConfig {
@@ -113,13 +111,13 @@ mod tests {
         };
 
         // Train a product quantizer
-        let pq_writer = ProductQuantizerWriter::new(pq_config.base_directory.clone());
+        let pq_writer = ProductQuantizerWriter::new(base_directory.clone());
         let mut pq_builder = ProductQuantizerBuilder::new(pq_config, pq_builder_config);
 
         for i in 0..1000 {
             pq_builder.add(datapoints[i].clone());
         }
-        let pq = pq_builder.build().unwrap();
+        let pq = pq_builder.build(base_directory.clone()).unwrap();
         pq_writer.write(&pq).unwrap();
 
         // Create a HNSW Builder

--- a/rs/index/src/hnsw/writer.rs
+++ b/rs/index/src/hnsw/writer.rs
@@ -428,8 +428,6 @@ mod tests {
             dimension: 128,
             subvector_dimension: 8,
             num_bits: 8,
-            base_directory: base_directory.clone(),
-            codebook_name: "codebook".to_string(),
         };
 
         let pq_builder_config = ProductQuantizerBuilderConfig {
@@ -438,13 +436,13 @@ mod tests {
         };
 
         // Train a product quantizer
-        let pq_writer = ProductQuantizerWriter::new(pq_config.base_directory.clone());
+        let pq_writer = ProductQuantizerWriter::new(base_directory.clone());
         let mut pq_builder = ProductQuantizerBuilder::new(pq_config, pq_builder_config);
 
         for i in 0..1000 {
             pq_builder.add(datapoints[i].clone());
         }
-        let pq = pq_builder.build().unwrap();
+        let pq = pq_builder.build(base_directory.clone()).unwrap();
         pq_writer.write(&pq).unwrap();
 
         // Create a HNSW Builder

--- a/rs/index_writer/Cargo.toml
+++ b/rs/index_writer/Cargo.toml
@@ -6,5 +6,10 @@ edition = "2021"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+env_logger.workspace = true
+log.workspace = true
 hdf5.workspace = true
+index.workspace = true
 ndarray.workspace = true
+quantization.workspace = true
+tempdir.workspace = true

--- a/rs/index_writer/src/config.rs
+++ b/rs/index_writer/src/config.rs
@@ -1,0 +1,28 @@
+// TODO(hicder): support more quantizers
+#[derive(Debug, Clone, Default)]
+pub enum QuantizerType {
+    #[default]
+    ProductQuantizer,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct IndexWriterConfig {
+    pub output_path: String,
+
+    // HNSW parameters
+    pub num_layers: u8,
+    pub max_num_neighbors: usize,
+    pub ef_construction: u32,
+
+    // Quantizer parameters
+    pub quantizer_type: QuantizerType,
+
+    pub dimension: usize,
+    pub subvector_dimension: usize,
+    pub num_bits: u8,
+    pub num_training_rows: usize,
+
+    // Quantizer builder parameters
+    pub max_iteration: usize,
+    pub batch_size: usize,
+}

--- a/rs/index_writer/src/index_writer.rs
+++ b/rs/index_writer/src/index_writer.rs
@@ -1,0 +1,85 @@
+use anyhow::Result;
+use index::hnsw::builder::HnswBuilder;
+use index::hnsw::writer::HnswWriter;
+use log::info;
+use quantization::pq::{ProductQuantizerConfig, ProductQuantizerWriter};
+use quantization::pq_builder::{ProductQuantizerBuilder, ProductQuantizerBuilderConfig};
+
+use crate::config::{IndexWriterConfig, QuantizerType};
+use crate::input::Input;
+
+pub struct IndexWriter {
+    config: IndexWriterConfig,
+}
+
+impl IndexWriter {
+    pub fn new(config: IndexWriterConfig) -> Self {
+        Self { config }
+    }
+
+    // TODO(hicder): Support multiple inputs
+    pub fn process(&mut self, input: &mut impl Input) -> Result<()> {
+        info!("Start indexing");
+        let pg_temp_dir = format!("{}/pq_tmp", self.config.output_path);
+        std::fs::create_dir_all(&pg_temp_dir)?;
+
+        // First, train the product quantizer
+        let mut pq_builder = match self.config.quantizer_type {
+            QuantizerType::ProductQuantizer => {
+                let pq_config = ProductQuantizerConfig {
+                    dimension: self.config.dimension,
+                    subvector_dimension: self.config.subvector_dimension,
+                    num_bits: self.config.num_bits,
+                };
+                let pq_builder_config = ProductQuantizerBuilderConfig {
+                    max_iteration: self.config.max_iteration,
+                    batch_size: self.config.batch_size,
+                };
+                ProductQuantizerBuilder::new(pq_config, pq_builder_config)
+            }
+        };
+
+        info!("Start training product quantizer");
+
+        // TODO(hicder): Sample instead of getting the first rows
+        let mut num_added = 0;
+        while input.has_next() && num_added < self.config.num_training_rows {
+            let row = input.next();
+            pq_builder.add(row.data.to_vec());
+            num_added += 1;
+        }
+        let pq = pq_builder.build(pg_temp_dir)?;
+
+        info!("Start writing product quantizer");
+        let pq_directory = format!("{}/quantizer", self.config.output_path);
+        std::fs::create_dir_all(&pq_directory)?;
+
+        let pq_writer = ProductQuantizerWriter::new(pq_directory);
+        pq_writer.write(&pq)?;
+
+        info!("Start building index");
+        // Then, build the index
+        let mut hnsw_builder = HnswBuilder::new(
+            self.config.max_num_neighbors,
+            self.config.num_layers,
+            self.config.ef_construction,
+            Box::new(pq),
+        );
+
+        input.reset();
+        while input.has_next() {
+            let row = input.next();
+            hnsw_builder.insert(row.id, row.data);
+        }
+
+        hnsw_builder.reindex()?;
+
+        let hnsw_directory = format!("{}/hnsw", self.config.output_path);
+        std::fs::create_dir_all(&hnsw_directory)?;
+
+        info!("Start writing index");
+        let hnsw_writer = HnswWriter::new(hnsw_directory);
+        hnsw_writer.write(&mut hnsw_builder, true)?;
+        Ok(())
+    }
+}

--- a/rs/index_writer/src/input/hdf5.rs
+++ b/rs/index_writer/src/input/hdf5.rs
@@ -3,6 +3,8 @@ use std::cmp::min;
 use anyhow::Result;
 use ndarray::{s, Array2};
 
+use super::{Input, Row};
+
 pub struct Hdf5Reader {
     dataset: hdf5::Dataset,
     chunk_size: usize,
@@ -25,22 +27,6 @@ impl Hdf5Reader {
         })
     }
 
-    pub fn has_next(&self) -> bool {
-        self.row_idx < self.num_rows
-    }
-
-    // Caller is responsible for ensuring that the chunk is not empty
-    pub fn next(&mut self) -> &[f32] {
-        if self.row_idx % self.chunk_size == 0 {
-            self.fetch_next_chunk();
-        }
-
-        let idx = self.row_idx % self.chunk_size;
-        let slice = &self.chunk[idx];
-        self.row_idx += 1;
-        slice
-    }
-
     pub fn fetch_next_chunk(&mut self) {
         self.chunk.clear();
         let end_idx = min(self.row_idx + self.chunk_size, self.num_rows);
@@ -48,6 +34,33 @@ impl Hdf5Reader {
         let chunk: Array2<f32> = self.dataset.read_slice_2d(selection).unwrap();
         for row in chunk.axis_iter(ndarray::Axis(0)) {
             self.chunk.push(row.to_vec());
+        }
+    }
+}
+
+impl Input for Hdf5Reader {
+    fn reset(&mut self) {
+        self.row_idx = 0;
+        self.chunk.clear();
+    }
+
+    fn has_next(&self) -> bool {
+        self.row_idx < self.num_rows
+    }
+
+    // Caller is responsible for ensuring that the chunk is not empty
+    fn next(&mut self) -> Row<'_> {
+        if self.row_idx % self.chunk_size == 0 {
+            self.fetch_next_chunk();
+        }
+
+        let idx = self.row_idx % self.chunk_size;
+        let doc_id = self.row_idx as u64;
+        let slice = &self.chunk[idx];
+        self.row_idx += 1;
+        Row {
+            id: doc_id,
+            data: slice,
         }
     }
 }

--- a/rs/index_writer/src/input/mod.rs
+++ b/rs/index_writer/src/input/mod.rs
@@ -1,1 +1,18 @@
 pub mod hdf5;
+
+pub struct Row<'a> {
+    pub id: u64,
+    pub data: &'a [f32],
+}
+
+pub trait Input {
+    // Return true if there are more rows to read
+    fn has_next(&self) -> bool;
+
+    // Return the next row of data
+    fn next(&mut self) -> Row;
+
+    // Reset the state of the input to the beginning
+    // This is helpful when we want to do multiple passes over the same input
+    fn reset(&mut self);
+}

--- a/rs/index_writer/src/lib.rs
+++ b/rs/index_writer/src/lib.rs
@@ -1,1 +1,3 @@
+pub mod config;
+pub mod index_writer;
 pub mod input;

--- a/rs/index_writer/src/main.rs
+++ b/rs/index_writer/src/main.rs
@@ -1,4 +1,7 @@
 use clap::Parser;
+use index_writer::config::IndexWriterConfig;
+use index_writer::index_writer::IndexWriter;
+use index_writer::input::hdf5::Hdf5Reader;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -8,11 +11,59 @@ struct Args {
     input_path: String,
 
     #[arg(short, long)]
+    dataset_name: String,
+
+    #[arg(short, long)]
     output_path: String,
+
+    #[arg(short, long, default_value_t = 8)]
+    num_layers: u8,
+
+    #[arg(short, long, default_value_t = 10)]
+    max_num_neighbors: usize,
+
+    #[arg(short, long, default_value_t = 10)]
+    ef_construction: u32,
+
+    #[arg(short, long, default_value_t = 128)]
+    dimension: usize,
+
+    #[arg(short, long, default_value_t = 8)]
+    subvector_dimension: usize,
+
+    #[arg(short, long, default_value_t = 8)]
+    num_bits: u8,
+
+    #[arg(short, long, default_value_t = 1000)]
+    num_training_rows: usize,
+
+    #[arg(short, long, default_value_t = 5)]
+    max_iteration: usize,
+
+    #[arg(short, long, default_value_t = 500)]
+    batch_size: usize,
 }
 
 fn main() {
-    let arg = Args::parse();
+    env_logger::init();
 
-    println!("{:?}", arg);
+    let arg = Args::parse();
+    let mut config = IndexWriterConfig::default();
+    config.output_path = arg.output_path.clone();
+    config.max_num_neighbors = arg.max_num_neighbors;
+    config.num_layers = arg.num_layers;
+    config.ef_construction = arg.ef_construction;
+    config.dimension = arg.dimension;
+    config.subvector_dimension = arg.subvector_dimension;
+    config.num_bits = arg.num_bits;
+    config.num_training_rows = arg.num_training_rows;
+    config.max_iteration = arg.max_iteration;
+    config.batch_size = arg.batch_size;
+
+    // Open input
+    let mut input = Hdf5Reader::new(1000, &arg.dataset_name, &arg.input_path).unwrap();
+    let mut index_writer = IndexWriter::new(config);
+
+    // Process
+    index_writer.process(&mut input).unwrap();
 }

--- a/rs/quantization/Cargo.toml
+++ b/rs/quantization/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow.workspace = true
 serde_yaml.workspace = true
 serde.workspace = true
 tempdir.workspace = true

--- a/rs/quantization/benches/pq_dist.rs
+++ b/rs/quantization/benches/pq_dist.rs
@@ -12,13 +12,12 @@ fn bench_pq_distance(c: &mut Criterion) {
     for dimension in [128, 256].iter() {
         for subvector_dimension in [4, 8, 16, 32, 64, 128].iter() {
             for num_bits in [4, 8, 16].iter() {
+                let tmpdir = tempdir::TempDir::new("pq_bench").unwrap();
                 let mut pqb = ProductQuantizerBuilder::new(
                     ProductQuantizerConfig {
                         dimension: *dimension,
                         subvector_dimension: *subvector_dimension,
                         num_bits: *num_bits,
-                        base_directory: "bm".to_string(),
-                        codebook_name: "bm".to_string(),
                     },
                     ProductQuantizerBuilderConfig {
                         max_iteration: 1000,
@@ -30,7 +29,9 @@ fn bench_pq_distance(c: &mut Criterion) {
                     pqb.add(generate_random_vector(*dimension));
                 }
 
-                let pq = pqb.build().unwrap();
+                let pq = pqb
+                    .build(tmpdir.path().to_str().unwrap().to_string())
+                    .unwrap();
                 let point = pq.quantize(&generate_random_vector(*dimension));
                 let query = pq.quantize(&generate_random_vector(*dimension));
                 for implementation in L2DistanceCalculatorImpl::iter() {


### PR DESCRIPTION
Only works with 1 input for now.

```
./target/release/index_writer --input-path /home/hieu/Downloads/sift-128-euclidean.hdf5 --output-path /tmp/test_hieu --dataset-name "/train"

[2024-10-31T17:22:19Z INFO  index_writer::index_writer] Start indexing
[2024-10-31T17:22:19Z INFO  index_writer::index_writer] Start training product quantizer
[2024-10-31T17:22:19Z INFO  index_writer::index_writer] Start writing product quantizer
[2024-10-31T17:22:19Z INFO  index_writer::index_writer] Start building index
[2024-10-31T17:23:04Z INFO  index_writer::index_writer] Start writing index
```

```
➜  test_hieu tree .
.
├── hnsw
│   └── index
├── pq_tmp
└── quantizer
    ├── codebook
    └── product_quantizer_config.yaml

4 directories, 3 files
```