### PR TITLE
Index manager for IndexServer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa",
+ "itoa 1.0.11",
  "matchit",
  "memchr",
  "mime",
@@ -372,6 +372,7 @@ dependencies = [
  "env_logger",
  "log",
  "proto",
+ "rand 0.8.5",
  "tokio",
  "tonic",
 ]
@@ -396,7 +397,7 @@ dependencies = [
  "criterion-plot",
  "itertools",
  "lazy_static",
- "num-traits",
+ "num-traits 0.2.19",
  "oorandom",
  "plotters",
  "rayon",
@@ -448,6 +449,12 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "either"
@@ -767,7 +774,7 @@ checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.11",
 ]
 
 [[package]]
@@ -814,7 +821,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.11",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -843,7 +850,7 @@ dependencies = [
  "bit-vec",
  "byteorder",
  "memmap2",
- "num-traits",
+ "num-traits 0.2.19",
  "ordered-float",
  "quantization",
  "rand 0.8.5",
@@ -858,11 +865,13 @@ dependencies = [
  "clap 4.5.20",
  "env_logger",
  "futures",
+ "index",
  "log",
  "prost",
  "proto",
  "rand 0.8.5",
  "serde",
+ "serde_json",
  "serde_yaml",
  "tokio",
  "tokio-stream",
@@ -923,6 +932,12 @@ dependencies = [
 
 [[package]]
 name = "itoa"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
+
+[[package]]
+name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
@@ -943,7 +958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ca5fef5e5202043d159d38ac0ca6e0aed6623a9eca3ca563590223f7350f13"
 dependencies = [
  "num",
- "num-traits",
+ "num-traits 0.2.19",
  "rand 0.8.5",
  "rayon",
 ]
@@ -1065,7 +1080,7 @@ dependencies = [
  "matrixmultiply",
  "num-complex",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
  "rawpointer",
 ]
 
@@ -1080,7 +1095,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -1090,7 +1105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -1099,7 +1114,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -1108,7 +1123,7 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -1119,7 +1134,7 @@ checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -1130,7 +1145,16 @@ checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
  "num-bigint",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -1169,7 +1193,7 @@ version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -1267,7 +1291,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
  "plotters-backend",
  "plotters-svg",
  "wasm-bindgen",
@@ -1646,13 +1670,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "1c62115693d0a9ed8c32d1c760f0fdbe7d4b05cb13c135b9b54137ac0d59fccb"
 dependencies = [
- "itoa",
- "memchr",
- "ryu",
+ "dtoa",
+ "itoa 0.3.4",
+ "num-traits 0.1.43",
  "serde",
 ]
 
@@ -1663,7 +1687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap 2.6.0",
- "itoa",
+ "itoa 1.0.11",
  "ryu",
  "serde",
  "unsafe-libyaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ clap = { version = "4.1.4", features = ["derive"] }
 tonic-reflection = "0.6.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
+serde_json = "=1.0.1"
 rand = "0.8.5"
 log = "0.4.22"
 env_logger = "0.11.5"

--- a/rs/cli/Cargo.toml
+++ b/rs/cli/Cargo.toml
@@ -10,3 +10,4 @@ log.workspace = true
 proto.workspace = true
 tokio.workspace = true
 tonic.workspace = true
+rand.workspace = true

--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -1,7 +1,8 @@
 use clap::Parser;
 use log::info;
 use proto::muopdb::aggregator_client::AggregatorClient;
-use proto::muopdb::GetRequest;
+use proto::muopdb::index_server_client::IndexServerClient;
+use proto::muopdb::{GetRequest, SearchRequest};
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -9,6 +10,9 @@ struct Args {
     /// Name of the person to greet
     #[arg(short, long, default_value_t = 9001)]
     port: u32,
+
+    #[arg(short, long, default_value_t = 0)]
+    node_type: u32,
 }
 
 #[tokio::main]
@@ -17,12 +21,27 @@ async fn main() {
 
     let arg = Args::parse();
     let addr = format!("http://127.0.0.1:{}", arg.port);
-    let mut client = AggregatorClient::connect(addr).await.unwrap();
 
-    let request = tonic::Request::new(GetRequest {
-        key: "test".to_string(),
-    });
+    let node_type = arg.node_type;
+    info!("Node type: {}", node_type);
 
-    let response = client.get(request).await.unwrap();
-    info!("Response: {:?}", response);
+    if node_type == 0 {
+        let mut client = AggregatorClient::connect(addr).await.unwrap();
+        let request = tonic::Request::new(GetRequest {
+            key: "test".to_string(),
+        });
+
+        let response = client.get(request).await.unwrap();
+        info!("Response: {:?}", response);
+    } else if node_type == 1 {
+        let mut client = IndexServerClient::connect(addr).await.unwrap();
+        let vec = (0..128).map(|_| rand::random::<f32>()).collect::<Vec<_>>();
+        let request = tonic::Request::new(SearchRequest {
+            index_name: "hieu-1".to_string(),
+            vector: vec,
+            top_k: 10,
+        });
+        let response = client.search(request).await.unwrap();
+        info!("Response: {:?}", response);
+    }
 }

--- a/rs/index/src/hnsw/reader.rs
+++ b/rs/index/src/hnsw/reader.rs
@@ -16,9 +16,9 @@ impl HnswReader {
     }
 
     pub fn read(&self) -> Hnsw {
-        let backing_file = File::open(format!("{}/index", self.base_directory)).unwrap();
+        let backing_file = File::open(format!("{}/hnsw/index", self.base_directory)).unwrap();
         let vector_storage_file =
-            File::open(format!("{}/vector_storage", self.base_directory)).unwrap();
+            File::open(format!("{}/hnsw/vector_storage", self.base_directory)).unwrap();
         let mmap = unsafe { Mmap::map(&backing_file).unwrap() };
 
         let (header, offset) = self.read_header(&mmap);

--- a/rs/index/src/index.rs
+++ b/rs/index/src/index.rs
@@ -2,5 +2,7 @@
 //! TODO(hicder): Add more methods
 pub trait Index {
     /// Search for the nearest neighbors of a query vector
-    fn search(&self, query: &[f32]) -> Option<Vec<u64>>;
+    fn search(&self, query: &[f32], k: usize) -> Option<Vec<u64>>;
 }
+
+pub type BoxedIndex = Box<dyn Index + Send + Sync>;

--- a/rs/index_server/Cargo.toml
+++ b/rs/index_server/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 
 [dependencies]
 proto.workspace = true
-tonic = "0.8"
+index.workspace = true
+tonic.workspace = true
 prost = "0.11"
 tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1", features = ["net"] }
@@ -13,7 +14,8 @@ futures = "0.3"
 clap = { version = "4.1.4", features = ["derive"] }
 tonic-reflection = "0.6.0"
 serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
-rand = "0.8.5"
+serde_yaml.workspace = true
+serde_json.workspace = true
+rand.workspace = true
 log.workspace = true
 env_logger.workspace = true

--- a/rs/index_server/src/index_catalog.rs
+++ b/rs/index_server/src/index_catalog.rs
@@ -1,0 +1,30 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use index::index::BoxedIndex;
+
+pub struct IndexCatalog {
+    indexes: HashMap<String, Arc<BoxedIndex>>,
+}
+
+impl IndexCatalog {
+    pub fn new() -> Self {
+        Self {
+            indexes: HashMap::new(),
+        }
+    }
+
+    pub async fn add_index(&mut self, name: String, index: Arc<BoxedIndex>) {
+        self.indexes.insert(name, index);
+    }
+
+    pub async fn get_index(&self, name: &str) -> Option<Arc<BoxedIndex>> {
+        self.indexes.get(name).map(|index| index.clone())
+    }
+
+    pub async fn get_all_index_names_sorted(&self) -> Vec<String> {
+        let mut v: Vec<String> = self.indexes.keys().cloned().collect();
+        v.sort();
+        v
+    }
+}

--- a/rs/index_server/src/index_provider.rs
+++ b/rs/index_server/src/index_provider.rs
@@ -1,0 +1,19 @@
+use index::hnsw::reader::HnswReader;
+use index::index::BoxedIndex;
+
+pub struct IndexProvider {
+    data_directory: String,
+}
+
+impl IndexProvider {
+    pub fn new(data_directory: String) -> Self {
+        Self { data_directory }
+    }
+
+    pub fn read_index(&self, name: &str) -> Option<BoxedIndex> {
+        let index_path = format!("{}/{}", self.data_directory, name);
+        let reader = HnswReader::new(index_path);
+        let index = reader.read();
+        Some(Box::new(index))
+    }
+}

--- a/rs/index_server/src/index_server.rs
+++ b/rs/index_server/src/index_server.rs
@@ -1,8 +1,21 @@
+use std::sync::Arc;
+
 use log::info;
 use proto::muopdb::index_server_server::IndexServer;
 use proto::muopdb::{SearchRequest, SearchResponse};
+use tokio::sync::Mutex;
 
-pub struct IndexServerImpl {}
+use crate::index_catalog::IndexCatalog;
+
+pub struct IndexServerImpl {
+    pub index_catalog: Arc<Mutex<IndexCatalog>>,
+}
+
+impl IndexServerImpl {
+    pub fn new(index_catalog: Arc<Mutex<IndexCatalog>>) -> Self {
+        Self { index_catalog }
+    }
+}
 
 #[tonic::async_trait]
 impl IndexServer for IndexServerImpl {
@@ -10,7 +23,19 @@ impl IndexServer for IndexServerImpl {
         &self,
         request: tonic::Request<SearchRequest>,
     ) -> Result<tonic::Response<SearchResponse>, tonic::Status> {
-        info!("Got a request: {:?}", request);
-        Ok(tonic::Response::new(SearchResponse { ids: vec![1, 2, 3] }))
+        let req = request.into_inner();
+        let index_name = req.index_name;
+        let vec = req.vector;
+        let k = req.top_k;
+
+        let index = self.index_catalog.lock().await.get_index(&index_name).await;
+        if let Some(index) = index {
+            let result = index.search(&vec, k as usize);
+            info!("Search result: {:?}", result);
+            return Ok(tonic::Response::new(SearchResponse {
+                ids: result.unwrap_or(vec![]),
+            }));
+        }
+        Ok(tonic::Response::new(SearchResponse { ids: vec![] }))
     }
 }

--- a/rs/index_server/src/main.rs
+++ b/rs/index_server/src/main.rs
@@ -1,11 +1,21 @@
+mod index_catalog;
+mod index_manager;
+mod index_provider;
 mod index_server;
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use clap::Parser;
+use index_catalog::IndexCatalog;
+use index_manager::IndexManager;
+use index_provider::IndexProvider;
 use index_server::IndexServerImpl;
 use log::info;
 use proto::muopdb::index_server_server::IndexServerServer;
+use tokio::spawn;
+use tokio::sync::Mutex;
+use tokio::time::sleep;
 use tonic::transport::Server;
 
 #[derive(Parser, Debug)]
@@ -13,6 +23,15 @@ use tonic::transport::Server;
 struct Args {
     #[arg(short, long, default_value_t = 9002)]
     port: u32,
+
+    #[arg(short, long)]
+    node_id: u32,
+
+    #[arg(long)]
+    index_config_path: String,
+
+    #[arg(long)]
+    index_data_path: String,
 }
 
 #[tokio::main]
@@ -20,13 +39,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let arg = Args::parse();
     let addr: SocketAddr = format!("127.0.0.1:{}", arg.port).parse().unwrap();
-    let server_impl = IndexServerImpl {};
+    let index_config_path = arg.index_config_path;
+    let index_data_path = arg.index_data_path;
+    let node_id = arg.node_id;
 
-    info!("Listening on port {}", arg.port);
+    let index_catalog = Arc::new(Mutex::new(IndexCatalog::new()));
+    let index_catalog_for_manager = index_catalog.clone();
+    let index_catalog_for_server = index_catalog.clone();
 
+    info!("Node: {}, listening on port {}", node_id, arg.port);
+
+    let index_manager_thread = spawn(async move {
+        let index_provider = IndexProvider::new(index_data_path);
+        let mut index_manager =
+            IndexManager::new(index_config_path, index_provider, index_catalog_for_manager);
+        loop {
+            index_manager.check_for_update().await;
+            sleep(std::time::Duration::from_secs(60)).await;
+        }
+    });
+
+    let server_impl = IndexServerImpl::new(index_catalog_for_server);
     Server::builder()
         .add_service(IndexServerServer::new(server_impl))
         .serve(addr)
         .await?;
+
+    // TODO(hicder): Add graceful shutdown
+    info!("Received signal, shutting down");
+    index_manager_thread.await?;
     Ok(())
 }


### PR DESCRIPTION
IndexServer is up and running!

```
# IndexServer runs with

muopdb git:(index-server-manager) env RUST_LOG=info ./target/release/index_server --node-id 0 --index-config-path /mnt/muopdb/indices --index-data-path /mnt/muopdb/data --port 9002

[2024-11-01T21:37:08Z INFO  index_server] Node: 0, listening on port 9002
[2024-11-01T21:37:08Z INFO  index_server::index_manager] New version available: 1
[2024-11-01T21:37:08Z INFO  index_server::index_manager] Fetching index hieu-1
[2024-11-01T21:37:14Z INFO  index_server::index_server] Search result: Some([116631, 94560, 137926, 74676, 972489, 437185, 136880, 411939, 257375, 115555])


# CLI to query:

muopdb git:(index-server-manager) env RUST_LOG=info ./target/release/cli --port=9002 --node-type=1

[2024-11-01T21:37:14Z INFO  cli] Node type: 1
[2024-11-01T21:37:14Z INFO  cli] Response: Response { metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Fri, 01 Nov 2024 21:37:14 GMT", "grpc-status": "0"} }, message: SearchResponse { ids: [116631, 94560, 137926, 74676, 972489, 437185, 136880, 411939, 257375, 115555] }, extensions: Extensions }
```

On-disk directories
```
➜  muopdb tree
.
├── data
│   └── hieu-1
│       ├── hnsw
│       │   ├── index
│       │   └── vector_storage
│       └── quantizer
│           ├── codebook
│           └── product_quantizer_config.yaml
└── indices
    └── version_1
```
