### PR TITLE
Use different context type for graph builder

### DIFF
--- a/extra_launch.json
+++ b/extra_launch.json
@@ -1,0 +1,48 @@
+{
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "[MUOPDB] Debug executable 'index_server'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=index_server",
+                    "--package=index_server"
+                ],
+                "filter": {
+                    "name": "index_server",
+                    "kind": "bin"
+                }
+            },
+            "args": [
+                "--node-id=0",
+                "--index-config-path=/mnt/muopdb/indices",
+                "--index-data-path=/mnt/muopdb/data"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "[MUOPDB] Debug executable 'index_writer'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=index_writer",
+                    "--package=index_writer"
+                ],
+                "filter": {
+                    "name": "index_writer",
+                    "kind": "bin"
+                }
+            },
+            "args": [
+                "--input-path=/home/hieu/Downloads/sift-128-euclidean.hdf5",
+                "--output-path=/tmp/test_hieu",
+                "--dataset-name=/train"
+            ],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/rs/index/src/hnsw/builder.rs
+++ b/rs/index/src/hnsw/builder.rs
@@ -8,7 +8,7 @@ use quantization::quantization::Quantizer;
 use rand::Rng;
 use utils::l2::L2DistanceCalculatorImpl::StreamingWithSIMD;
 
-use super::utils::{GraphTraversal, PointAndDistance, SearchContext};
+use super::utils::{BuilderContext, GraphTraversal, PointAndDistance};
 use crate::vector::VectorStorage;
 
 /// TODO(hicder): support bare vector in addition to quantized one.
@@ -152,7 +152,7 @@ impl HnswBuilder {
     pub fn insert(&mut self, doc_id: u64, vector: &[f32]) -> Result<()> {
         let quantized_query = self.quantizer.quantize(vector);
         let point_id = self.generate_id(doc_id);
-        let mut context = SearchContext::new();
+        let mut context = BuilderContext::new(point_id + 1);
 
         let empty_graph = point_id == 0;
         self.append_vector_to_storage(&quantized_query)?;
@@ -354,6 +354,8 @@ impl HnswBuilder {
 }
 
 impl GraphTraversal for HnswBuilder {
+    type ContextT = BuilderContext;
+
     fn distance(&self, query: &[u8], point_id: u32) -> f32 {
         self.quantizer
             .distance(query, self.get_vector(point_id), StreamingWithSIMD)


### PR DESCRIPTION
RoaringBitmap is much slower than BitVec. But BitVec requires preallocating memory before hand (which is bad if we do it for all queries). Therefore:
* Use `BitVec` for graph builder
* Use `RoaringBitmap` for search query