### PR TITLE
 Implement IVF index in index_writer

### DIFF
--- a/rs/index/src/ivf/builder.rs
+++ b/rs/index/src/ivf/builder.rs
@@ -196,6 +196,19 @@ impl IvfBuilder {
 
         Ok(())
     }
+
+    pub fn cleanup(&mut self) -> Result<()> {
+        let vectors_path = format!("{}/builder_vector_storage", self.config.base_directory);
+        let centroids_path = format!("{}/builder_centroid_storage", self.config.base_directory);
+        let posting_lists_path = format!(
+            "{}/builder_posting_list_storage",
+            self.config.base_directory
+        );
+        std::fs::remove_dir_all(&vectors_path)?;
+        std::fs::remove_dir_all(&centroids_path)?;
+        std::fs::remove_dir_all(&posting_lists_path)?;
+        Ok(())
+    }
 }
 
 // Test


### PR DESCRIPTION
Repro:
```
$ cargo build --release
$ RUST_LOG=info ./target/release/index_writer --input-path ~/Downloads/sift-128-euclidean.hdf5 --output-path /tmp/test --dataset-name "train" ivf
[2024-11-29T16:28:04Z INFO  index_writer::index_writer] Start indexing (IVF)
[2024-11-29T16:28:04Z INFO  index_writer::index_writer] Start building index
[2024-11-29T16:28:06Z INFO  index_writer::index_writer] Start writing index
$ RUST_LOG=info ./target/release/index_writer --input-path ~/Downloads/sift-128-euclidean.hdf5 --output-path /tmp/test --dataset-name "train" hnsw
[2024-11-29T16:29:14Z INFO  index_writer::index_writer] Start indexing (HNSW)
[2024-11-29T16:29:14Z INFO  index_writer::index_writer] Start training product quantizer
[2024-11-29T16:29:14Z INFO  index_writer::index_writer] Start writing product quantizer
[2024-11-29T16:29:14Z INFO  index_writer::index_writer] Start building index
[2024-11-29T16:30:30Z INFO  index_writer::index_writer] Start writing index
$ tree /tmp/test
tree /tmp/test 
/tmp/test
├── hnsw
│   ├── index
│   └── vector_storage
├── ivf
│   ├── index
│   └── vectors
└── quantizer
    ├── codebook
    └── product_quantizer_config.yaml
```