### PR TITLE
num_probes should be provided in search

### DIFF
--- a/rs/index/src/ivf/builder.rs
+++ b/rs/index/src/ivf/builder.rs
@@ -17,7 +17,6 @@ pub struct IvfBuilderConfig {
     pub max_iteration: usize,
     pub batch_size: usize,
     pub num_clusters: usize,
-    pub num_probes: usize,
     pub num_data_points: usize,
     pub max_clusters_per_vector: usize,
 
@@ -242,7 +241,6 @@ mod tests {
             max_iteration: 1000,
             batch_size: 4,
             num_clusters,
-            num_probes: 2,
             num_data_points: num_vectors,
             max_clusters_per_vector: 1,
             base_directory,

--- a/rs/index/src/ivf/reader.rs
+++ b/rs/index/src/ivf/reader.rs
@@ -23,7 +23,7 @@ impl IvfReader {
         )?;
 
         let num_clusters = index_storage.header().num_clusters as usize;
-        Ok(Ivf::new(vector_storage, index_storage, num_clusters, 1))
+        Ok(Ivf::new(vector_storage, index_storage, num_clusters))
     }
 }
 
@@ -59,7 +59,6 @@ mod tests {
             max_iteration: 1000,
             batch_size: 4,
             num_clusters,
-            num_probes: 2,
             num_data_points: num_vectors,
             max_clusters_per_vector: 1,
             base_directory: base_directory.clone(),

--- a/rs/index/src/ivf/writer.rs
+++ b/rs/index/src/ivf/writer.rs
@@ -305,7 +305,6 @@ mod tests {
             max_iteration: 1000,
             batch_size: 4,
             num_clusters,
-            num_probes: 2,
             num_data_points: num_vectors,
             max_clusters_per_vector: 1,
             base_directory: base_directory.clone(),


### PR DESCRIPTION
`num_probes` should not be part of the builder or the index but a parameter to each invocation of `search`