### PR TITLE
Fix SPANN reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,6 +1179,7 @@ dependencies = [
  "env_logger",
  "futures",
  "index",
+ "index_writer",
  "log",
  "prost",
  "proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ proto = {path='./rs/proto'}
 quantization = {path='./rs/quantization'}
 utils = {path='./rs/utils'}
 index = {path='./rs/index'}
+index_writer = {path='./rs/index_writer'}
 tonic = "0.8"
 prost = "0.11"
 tonic-build = "0.8"

--- a/rs/index/src/spann/reader.rs
+++ b/rs/index/src/spann/reader.rs
@@ -15,8 +15,11 @@ impl SpannReader {
     }
 
     pub fn read(&self) -> Result<Spann> {
-        let centroids = HnswReader::new(self.base_directory.clone()).read::<NoQuantizer>()?;
-        let posting_lists = IvfReader::new(self.base_directory.clone()).read()?;
+        let posting_list_path = format!("{}/ivf", self.base_directory);
+        let centroid_path = format!("{}/centroids", self.base_directory);
+
+        let centroids = HnswReader::new(centroid_path).read::<NoQuantizer>()?;
+        let posting_lists = IvfReader::new(posting_list_path).read()?;
 
         Ok(Spann::new(centroids, posting_lists))
     }

--- a/rs/index_server/Cargo.toml
+++ b/rs/index_server/Cargo.toml
@@ -22,3 +22,4 @@ tonic-reflection = "0.6.0"
 tonic.workspace = true
 utils.workspace = true
 quantization.workspace = true
+index_writer.workspace = true

--- a/rs/index_server/src/index_provider.rs
+++ b/rs/index_server/src/index_provider.rs
@@ -1,5 +1,7 @@
 use index::hnsw::reader::HnswReader;
 use index::index::BoxedIndex;
+use index::spann::reader::SpannReader;
+use index_writer::config::BaseConfig;
 use quantization::pq::ProductQuantizer;
 
 pub struct IndexProvider {
@@ -13,12 +15,33 @@ impl IndexProvider {
 
     pub fn read_index(&self, name: &str) -> Option<BoxedIndex> {
         let index_path = format!("{}/{}", self.data_directory, name);
-        let reader = HnswReader::new(index_path);
-        match reader.read::<ProductQuantizer>() {
-            Ok(index) => Some(Box::new(index)),
-            Err(e) => {
-                println!("Failed to read index: {}", e);
-                None
+        let index_writer_config_path = format!("{}/base_config.yaml", index_path);
+
+        let base_config: BaseConfig =
+            serde_yaml::from_reader(std::fs::File::open(index_writer_config_path).unwrap())
+                .unwrap();
+
+        match base_config.index_type {
+            index_writer::config::IndexType::Hnsw => {
+                let reader = HnswReader::new(index_path);
+                match reader.read::<ProductQuantizer>() {
+                    Ok(index) => Some(Box::new(index)),
+                    Err(e) => {
+                        println!("Failed to read index: {}", e);
+                        None
+                    }
+                }
+            }
+            index_writer::config::IndexType::Ivf => todo!(),
+            index_writer::config::IndexType::HnswIvf => {
+                let reader = SpannReader::new(index_path);
+                match reader.read() {
+                    Ok(index) => Some(Box::new(index)),
+                    Err(e) => {
+                        println!("Failed to read index: {}", e);
+                        None
+                    }
+                }
             }
         }
     }

--- a/rs/index_writer/src/config.rs
+++ b/rs/index_writer/src/config.rs
@@ -9,6 +9,15 @@ pub enum QuantizerType {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub enum IndexType {
+    Hnsw,
+    Ivf,
+
+    #[default]
+    HnswIvf,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct BaseConfig {
     pub output_path: String,
     pub dimension: usize,
@@ -16,6 +25,8 @@ pub struct BaseConfig {
     // Vector storage parameters
     pub max_memory_size: usize,
     pub file_size: usize,
+
+    pub index_type: IndexType,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/rs/index_writer/src/scripts/write_index_writer_config.rs
+++ b/rs/index_writer/src/scripts/write_index_writer_config.rs
@@ -11,6 +11,7 @@ fn main() -> std::io::Result<()> {
     base_config.output_path = "NONE".to_string();
     base_config.max_memory_size = 1024 * 1024 * 1024; // 1 GB
     base_config.file_size = 1024 * 1024 * 1024; // 1 GB
+    base_config.index_type = index_writer::config::IndexType::HnswIvf;
 
     let mut ivf_config = IvfConfig::default();
     ivf_config.num_clusters = 5;


### PR DESCRIPTION
Make the directory better for SPANN:
```
├── base_config.yaml
├── centroids
│   ├── hnsw
│   │   ├── index
│   │   └── vector_storage
│   └── quantizer
│       └── no_op_quantizer_config.yaml
└── ivf
    ├── index
    └── vectors
```