### PR TITLE
Make index_writer easier to benchmark

### DIFF
--- a/rs/index_writer/src/config.rs
+++ b/rs/index_writer/src/config.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub enum QuantizerType {
     #[default]
-    ProductQuantizer,
     NoQuantizer,
+    ProductQuantizer,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -96,6 +96,64 @@ pub enum IndexWriterConfig {
 
 impl Default for IndexWriterConfig {
     fn default() -> Self {
-        IndexWriterConfig::Hnsw(HnswConfigWithBase::default())
+        IndexWriterConfig::Spann(SpannConfigWithBase::default())
+    }
+}
+
+pub fn default_base_config_for_bm(
+    reindex: bool,
+    quantize: bool,
+    index_type: IndexType,
+) -> BaseConfig {
+    let output_path = format!(
+        "/tmp/{:?}{}{}",
+        index_type,
+        if reindex { "_reindex" } else { "_no_reindex" },
+        if quantize { "_pq" } else { "_no_pq" },
+    )
+    .to_lowercase();
+    BaseConfig {
+        reindex,
+        dimension: 128,
+        output_path,
+        max_memory_size: 1024 * 1024 * 1024, // 1 GB
+        file_size: 1024 * 1024 * 1024,       // 1 GB
+        index_type,
+    }
+}
+
+pub fn default_quantizer_config_for_bm(quantize: bool) -> QuantizerConfig {
+    if quantize {
+        QuantizerConfig {
+            quantizer_type: QuantizerType::ProductQuantizer,
+            subvector_dimension: 8,
+            num_bits: 8,
+            num_training_rows: 10000,
+            max_iteration: 1000,
+            batch_size: 4,
+        }
+    } else {
+        QuantizerConfig::default()
+    }
+}
+
+pub fn default_ivf_config_for_bm() -> IvfConfig {
+    IvfConfig {
+        num_clusters: 10,
+        num_data_points: 100000,
+        max_clusters_per_vector: 1,
+        distance_threshold: 0.1,
+        max_iteration: 1000,
+        batch_size: 4,
+        tolerance: 0.0,
+        max_posting_list_size: 1000,
+    }
+}
+
+pub fn default_hnsw_config_for_bm() -> HnswConfig {
+    HnswConfig {
+        num_layers: 4,
+        max_num_neighbors: 32,
+        ef_construction: 200,
     }
 }

--- a/rs/index_writer/src/main.rs
+++ b/rs/index_writer/src/main.rs
@@ -2,9 +2,7 @@ use std::io::Read;
 use std::path::Path;
 
 use clap::Parser;
-use index_writer::config::{
-    HnswConfigWithBase, IndexWriterConfig, IvfConfigWithBase, SpannConfigWithBase,
-};
+use index_writer::config::*;
 use index_writer::index_writer::IndexWriter;
 use index_writer::input::hdf5::Hdf5Reader;
 
@@ -26,11 +24,17 @@ struct Args {
     #[arg(long, required = true)]
     dataset_name: String,
 
-    #[arg(long, required = true)]
-    output_path: String,
+    #[arg(long, required = false)]
+    output_path: Option<String>,
 
-    #[arg(long, required = true)]
-    config_path: String,
+    #[arg(long, required = false)]
+    config_path: Option<String>,
+
+    #[arg(long, default_value_t = false, required = false)]
+    reindex: bool,
+
+    #[arg(long, default_value_t = false, required = false)]
+    quantize: bool,
 
     #[arg(long = "index-type", required = true, value_enum)]
     index_type: IndexTypeArgs,
@@ -40,30 +44,73 @@ fn main() {
     env_logger::init();
 
     let arg = Args::parse();
-    let mut file =
-        std::fs::File::open(Path::new(&arg.config_path)).expect("Failed to open config file");
-    let mut buf = String::new();
-    file.read_to_string(&mut buf)
-        .expect("Failed to read config file");
 
-    let config = match arg.index_type {
-        IndexTypeArgs::Hnsw => {
-            let mut config: HnswConfigWithBase =
-                serde_yaml::from_str(&buf).expect("Failed to parse config");
-            config.base_config.output_path = arg.output_path;
-            IndexWriterConfig::Hnsw(config)
+    let config: IndexWriterConfig = match arg.config_path {
+        Some(path) => {
+            let mut file =
+                std::fs::File::open(Path::new(&path)).expect("Failed to open config file");
+            let mut buf = String::new();
+            file.read_to_string(&mut buf)
+                .expect("Failed to read config file");
+
+            let output_path = arg
+                .output_path
+                .expect("output_path is required when providing a custom config file");
+            match arg.index_type {
+                IndexTypeArgs::Hnsw => {
+                    let mut config: HnswConfigWithBase =
+                        serde_yaml::from_str(&buf).expect("Failed to parse config");
+                    config.base_config.output_path = output_path;
+                    IndexWriterConfig::Hnsw(config)
+                }
+                IndexTypeArgs::Ivf => {
+                    let mut config: IvfConfigWithBase =
+                        serde_yaml::from_str(&buf).expect("Failed to parse config");
+                    config.base_config.output_path = output_path;
+                    IndexWriterConfig::Ivf(config)
+                }
+                IndexTypeArgs::Spann => {
+                    let mut config: SpannConfigWithBase =
+                        serde_yaml::from_str(&buf).expect("Failed to parse config");
+                    config.base_config.output_path = output_path;
+                    IndexWriterConfig::Spann(config)
+                }
+            }
         }
-        IndexTypeArgs::Ivf => {
-            let mut config: IvfConfigWithBase =
-                serde_yaml::from_str(&buf).expect("Failed to parse config");
-            config.base_config.output_path = arg.output_path;
-            IndexWriterConfig::Ivf(config)
-        }
-        IndexTypeArgs::Spann => {
-            let mut config: SpannConfigWithBase =
-                serde_yaml::from_str(&buf).expect("Failed to parse config");
-            config.base_config.output_path = arg.output_path;
-            IndexWriterConfig::Spann(config)
+        None => {
+            let quantizer_config = default_quantizer_config_for_bm(arg.quantize);
+            let ivf_config = default_ivf_config_for_bm();
+            let hnsw_config = default_hnsw_config_for_bm();
+            match arg.index_type {
+                IndexTypeArgs::Hnsw => IndexWriterConfig::Hnsw(HnswConfigWithBase {
+                    base_config: default_base_config_for_bm(
+                        arg.reindex,
+                        arg.quantize,
+                        IndexType::Hnsw,
+                    ),
+                    quantizer_config,
+                    hnsw_config,
+                }),
+                IndexTypeArgs::Ivf => IndexWriterConfig::Ivf(IvfConfigWithBase {
+                    base_config: default_base_config_for_bm(
+                        arg.reindex,
+                        arg.quantize,
+                        IndexType::Ivf,
+                    ),
+                    quantizer_config,
+                    ivf_config,
+                }),
+                IndexTypeArgs::Spann => IndexWriterConfig::Spann(SpannConfigWithBase {
+                    base_config: default_base_config_for_bm(
+                        arg.reindex,
+                        arg.quantize,
+                        IndexType::Spann,
+                    ),
+                    quantizer_config,
+                    ivf_config,
+                    hnsw_config,
+                }),
+            }
         }
     };
 

--- a/rs/index_writer/src/scripts/write_index_writer_config.rs
+++ b/rs/index_writer/src/scripts/write_index_writer_config.rs
@@ -9,15 +9,20 @@ use index_writer::config::{
 
 fn main() -> std::io::Result<()> {
     let mut base_config = BaseConfig::default();
-    base_config.reindex = false;
+    base_config.reindex = true;
     base_config.dimension = 128;
     base_config.output_path = "NONE".to_string();
     base_config.max_memory_size = 1024 * 1024 * 1024; // 1 GB
     base_config.file_size = 1024 * 1024 * 1024; // 1 GB
-    base_config.index_type = index_writer::config::IndexType::Spann;
+    base_config.index_type = index_writer::config::IndexType::Ivf;
 
     let mut quantizer_config = QuantizerConfig::default();
-    quantizer_config.quantizer_type = QuantizerType::NoQuantizer;
+    quantizer_config.quantizer_type = QuantizerType::ProductQuantizer;
+    quantizer_config.subvector_dimension = 8;
+    quantizer_config.num_bits = 8;
+    quantizer_config.num_training_rows = 10000;
+    quantizer_config.max_iteration = 1000;
+    quantizer_config.batch_size = 4;
 
     let mut ivf_config = IvfConfig::default();
     ivf_config.num_clusters = 5;
@@ -34,6 +39,7 @@ fn main() -> std::io::Result<()> {
 
     let mut config = SpannConfigWithBase::default();
     config.base_config = base_config;
+    config.quantizer_config = quantizer_config;
     config.ivf_config = ivf_config;
     config.hnsw_config = hnsw_config;
 


### PR DESCRIPTION
Doing so by providing default values to configs, and avoid passing config file to `index_writer`. Also automatically picking an `output_path` depending on different parameters