### PR TITLE
Use RwLock instead of Mutex for versions info

### DIFF
--- a/rs/compression/src/elias_fano/ef.rs
+++ b/rs/compression/src/elias_fano/ef.rs
@@ -73,6 +73,7 @@ impl EliasFano {
     }
 
     /// Returns the value at the given index
+    #[allow(dead_code)]
     fn get(&self, index: usize) -> Result<u64> {
         if index >= self.size {
             return Err(anyhow!("Index {} out of bound", index));


### PR DESCRIPTION
As titled. This allows multiple reads