### PR TITLE
GRPC endpoint for insert and flush

### DIFF
--- a/rs/index_server/src/index_server.rs
+++ b/rs/index_server/src/index_server.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use index::utils::SearchContext;
 use log::info;
 use proto::muopdb::index_server_server::IndexServer;
-use proto::muopdb::{SearchRequest, SearchResponse};
+use proto::muopdb::{
+    FlushRequest, FlushResponse, InsertRequest, InsertResponse, SearchRequest, SearchResponse,
+};
 use tokio::sync::Mutex;
 
 use crate::index_catalog::IndexCatalog;
@@ -65,5 +67,19 @@ impl IndexServer for IndexServerImpl {
             scores: vec![],
             num_pages_accessed: 0,
         }))
+    }
+
+    async fn insert(
+        &self,
+        _request: tonic::Request<InsertRequest>,
+    ) -> Result<tonic::Response<InsertResponse>, tonic::Status> {
+        todo!()
+    }
+
+    async fn flush(
+        &self,
+        _request: tonic::Request<FlushRequest>,
+    ) -> Result<tonic::Response<FlushResponse>, tonic::Status> {
+        todo!()
     }
 }

--- a/rs/proto/proto/muopdb.proto
+++ b/rs/proto/proto/muopdb.proto
@@ -24,6 +24,10 @@ message GetResponse {
 
 service IndexServer {
   rpc Search(SearchRequest) returns (SearchResponse) {}
+
+  rpc Insert(InsertRequest) returns (InsertResponse) {}
+
+  rpc Flush(FlushRequest) returns (FlushResponse) {}
 }
 
 message SearchRequest {
@@ -42,4 +46,25 @@ message SearchResponse {
 
   // For metrics, not enabled by default
   uint64 num_pages_accessed = 3;
+}
+
+message InsertRequest {
+  string collection_name = 1;
+
+  repeated uint64 ids = 2;
+
+  // flattened vector
+  repeated float vectors = 3;
+}
+
+message InsertResponse {
+  repeated uint64 inserted_ids = 1;
+}
+
+message FlushRequest {
+  string collection_name = 1;
+}
+
+message FlushResponse {
+  repeated string flushed_segments = 1;
 }

--- a/rs/proto/src/muopdb.rs
+++ b/rs/proto/src/muopdb.rs
@@ -48,6 +48,35 @@ pub struct SearchResponse {
     #[prost(uint64, tag = "3")]
     pub num_pages_accessed: u64,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct InsertRequest {
+    #[prost(string, tag = "1")]
+    pub collection_name: ::prost::alloc::string::String,
+    #[prost(uint64, repeated, tag = "2")]
+    pub ids: ::prost::alloc::vec::Vec<u64>,
+    /// flattened vector
+    #[prost(float, repeated, tag = "3")]
+    pub vectors: ::prost::alloc::vec::Vec<f32>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct InsertResponse {
+    #[prost(uint64, repeated, tag = "1")]
+    pub inserted_ids: ::prost::alloc::vec::Vec<u64>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FlushRequest {
+    #[prost(string, tag = "1")]
+    pub collection_name: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FlushResponse {
+    #[prost(string, repeated, tag = "1")]
+    pub flushed_segments: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
 /// Generated client implementations.
 pub mod aggregator_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -224,6 +253,42 @@ pub mod index_server_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+        pub async fn insert(
+            &mut self,
+            request: impl tonic::IntoRequest<super::InsertRequest>,
+        ) -> Result<tonic::Response<super::InsertResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/muopdb.IndexServer/Insert",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn flush(
+            &mut self,
+            request: impl tonic::IntoRequest<super::FlushRequest>,
+        ) -> Result<tonic::Response<super::FlushResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/muopdb.IndexServer/Flush");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -383,6 +448,14 @@ pub mod index_server_server {
             &self,
             request: tonic::Request<super::SearchRequest>,
         ) -> Result<tonic::Response<super::SearchResponse>, tonic::Status>;
+        async fn insert(
+            &self,
+            request: tonic::Request<super::InsertRequest>,
+        ) -> Result<tonic::Response<super::InsertResponse>, tonic::Status>;
+        async fn flush(
+            &self,
+            request: tonic::Request<super::FlushRequest>,
+        ) -> Result<tonic::Response<super::FlushResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct IndexServerServer<T: IndexServer> {
@@ -470,6 +543,80 @@ pub mod index_server_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = SearchSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/muopdb.IndexServer/Insert" => {
+                    #[allow(non_camel_case_types)]
+                    struct InsertSvc<T: IndexServer>(pub Arc<T>);
+                    impl<
+                        T: IndexServer,
+                    > tonic::server::UnaryService<super::InsertRequest>
+                    for InsertSvc<T> {
+                        type Response = super::InsertResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::InsertRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).insert(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = InsertSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/muopdb.IndexServer/Flush" => {
+                    #[allow(non_camel_case_types)]
+                    struct FlushSvc<T: IndexServer>(pub Arc<T>);
+                    impl<T: IndexServer> tonic::server::UnaryService<super::FlushRequest>
+                    for FlushSvc<T> {
+                        type Response = super::FlushResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::FlushRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).flush(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = FlushSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(


### PR DESCRIPTION
Add `insert` and `flush` endpoints for `index_server`. This will be used for a quick POC where we will insert and manually flush to create a segment.