### PR TITLE
Optimize SPANN & IVF writers

### DIFF
--- a/rs/index/src/spann/builder.rs
+++ b/rs/index/src/spann/builder.rs
@@ -1,4 +1,5 @@
 use anyhow::{Ok, Result};
+use log::debug;
 use quantization::noq::noq::NoQuantizer;
 use serde::{Deserialize, Serialize};
 
@@ -116,6 +117,7 @@ impl SpannBuilder {
 
     pub fn build(&mut self) -> Result<()> {
         self.ivf_builder.build()?;
+        debug!("Finish building IVF index");
 
         let centroid_storage = self.ivf_builder.centroids();
         let num_centroids = centroid_storage.borrow().len();
@@ -124,7 +126,7 @@ impl SpannBuilder {
             self.centroid_builder
                 .insert(i as u64, &centroid_storage.borrow().get(i as u32).unwrap())?;
         }
-
+        debug!("Finish building centroids");
         Ok(())
     }
 }

--- a/rs/index/src/spann/writer.rs
+++ b/rs/index/src/spann/writer.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use log::debug;
 use quantization::noq::noq::{NoQuantizer, NoQuantizerWriter};
 
 use super::builder::SpannBuilder;
@@ -26,11 +27,13 @@ impl SpannWriter {
         let hnsw_directory = format!("{}/hnsw", centroid_directory);
         std::fs::create_dir_all(&hnsw_directory)?;
 
+        debug!("Writing centroids");
         let hnsw_writer = HnswWriter::new(hnsw_directory);
         hnsw_writer.write(
             &mut spann_builder.centroid_builder,
             index_writer_config.reindex,
         )?;
+        debug!("Finish writing centroids");
 
         // Write the quantizer to disk, even though it's no quantizer
         let quantizer_writer = NoQuantizerWriter::new(centroid_quantizer_directory);
@@ -46,9 +49,11 @@ impl SpannWriter {
         let ivf_quantizer_writer = NoQuantizerWriter::new(ivf_quantizer_directory);
         ivf_quantizer_writer.write(&ivf_quantizer)?;
 
+        debug!("Writing IVF index");
         let ivf_writer = IvfWriter::new(ivf_directory, ivf_quantizer);
         ivf_writer.write(&mut spann_builder.ivf_builder, index_writer_config.reindex)?;
         spann_builder.ivf_builder.cleanup()?;
+        debug!("Finish writing IVF index");
 
         Ok(())
     }


### PR DESCRIPTION
This PR introduces 2 optimizations:
* In IVFWriter, when writing vectors, avoid writing to a temporary `FileBackedVectorStorage`
* In `FileBackedVectorStorage`, write the vector directly to `mmap` instead of creating a temporary in-memory buffer

Result (33% improvement):
* Before: indexing takes 45s
* After: indexing takes 31s