### PR TITLE
Introduce insert_binary API to for zero-copy insert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tonic",
+ "utils",
 ]
 
 [[package]]

--- a/rs/demo/Cargo.toml
+++ b/rs/demo/Cargo.toml
@@ -15,6 +15,7 @@ ndarray.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
 serde.workspace = true
+utils.workspace = true
 
 [[bin]]
 name = "insert"

--- a/rs/index/src/ivf/writer.rs
+++ b/rs/index/src/ivf/writer.rs
@@ -1,3 +1,4 @@
+use std::cmp::min;
 use std::fs::{create_dir_all, remove_dir_all, remove_file, File};
 use std::io::{BufWriter, Write};
 
@@ -124,7 +125,8 @@ impl<Q: Quantizer> IvfWriter<Q> {
         // Write quantized vectors
         let path = format!("{}/vectors", self.base_directory);
         let mut file = File::create(path)?;
-        let mut writer = BufWriter::new(&mut file);
+        let capacity = full_vectors.borrow().len() * self.quantizer.quantized_dimension() * std::mem::size_of::<Q::QuantizedT>();
+        let mut writer = BufWriter::with_capacity(min(1 << 30, capacity), &mut file);
 
         let mut bytes_written = 0;
         bytes_written += wrap_write(&mut writer, &full_vectors.borrow().len().to_le_bytes())?;

--- a/rs/proto/proto/muopdb.proto
+++ b/rs/proto/proto/muopdb.proto
@@ -27,6 +27,8 @@ service IndexServer {
 
   rpc Insert(InsertRequest) returns (InsertResponse) {}
 
+  rpc InsertBinary(InsertBinaryRequest) returns (InsertBinaryResponse) {}
+
   rpc Flush(FlushRequest) returns (FlushResponse) {}
 }
 
@@ -67,4 +69,13 @@ message FlushRequest {
 
 message FlushResponse {
   repeated string flushed_segments = 1;
+}
+
+message InsertBinaryRequest {
+  string collection_name = 1;
+  bytes ids = 2;
+  bytes vectors = 3;
+}
+
+message InsertBinaryResponse {
 }

--- a/rs/proto/src/muopdb.rs
+++ b/rs/proto/src/muopdb.rs
@@ -77,6 +77,19 @@ pub struct FlushResponse {
     #[prost(string, repeated, tag = "1")]
     pub flushed_segments: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct InsertBinaryRequest {
+    #[prost(string, tag = "1")]
+    pub collection_name: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "2")]
+    pub ids: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub vectors: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct InsertBinaryResponse {}
 /// Generated client implementations.
 pub mod aggregator_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -272,6 +285,25 @@ pub mod index_server_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+        pub async fn insert_binary(
+            &mut self,
+            request: impl tonic::IntoRequest<super::InsertBinaryRequest>,
+        ) -> Result<tonic::Response<super::InsertBinaryResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/muopdb.IndexServer/InsertBinary",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
         pub async fn flush(
             &mut self,
             request: impl tonic::IntoRequest<super::FlushRequest>,
@@ -452,6 +484,10 @@ pub mod index_server_server {
             &self,
             request: tonic::Request<super::InsertRequest>,
         ) -> Result<tonic::Response<super::InsertResponse>, tonic::Status>;
+        async fn insert_binary(
+            &self,
+            request: tonic::Request<super::InsertBinaryRequest>,
+        ) -> Result<tonic::Response<super::InsertBinaryResponse>, tonic::Status>;
         async fn flush(
             &self,
             request: tonic::Request<super::FlushRequest>,
@@ -581,6 +617,46 @@ pub mod index_server_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = InsertSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/muopdb.IndexServer/InsertBinary" => {
+                    #[allow(non_camel_case_types)]
+                    struct InsertBinarySvc<T: IndexServer>(pub Arc<T>);
+                    impl<
+                        T: IndexServer,
+                    > tonic::server::UnaryService<super::InsertBinaryRequest>
+                    for InsertBinarySvc<T> {
+                        type Response = super::InsertBinaryResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::InsertBinaryRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).insert_binary(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = InsertBinarySvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(


### PR DESCRIPTION
Protobuf deserialization takes up 50% of CPU. We don't need it since we deserialize into a contiguous vector anyway

Before
```
[2025-01-01T18:10:55.167Z INFO  insert] Inserted all documents in 16.947639482s
```

After
```
[2025-01-01T18:46:04.902Z INFO  insert] Inserted all documents in 8.948953746s
```