### PR TITLE
[WIP] Lifetime just does not work

### DIFF
--- a/rs/compression/src/compression.rs
+++ b/rs/compression/src/compression.rs
@@ -20,12 +20,12 @@ pub trait IntSeqEncoder {
     fn write(&self, writer: &mut BufWriter<&mut File>) -> Result<usize>;
 }
 
-pub trait IntSeqDecoderIterator: Iterator {
+pub trait IntSeqDecoderIterator: Iterator<Item = u64> {
     /// Creates a decoder
     fn new_decoder(encoded_data: &[u8]) -> Self
     where
         Self: Sized;
 
     /// Returns the number of elements in the sequence
-    fn len(&self) -> usize;
+    fn num_elem(&self) -> usize;
 }

--- a/rs/compression/src/compression.rs
+++ b/rs/compression/src/compression.rs
@@ -20,9 +20,9 @@ pub trait IntSeqEncoder {
     fn write(&self, writer: &mut BufWriter<&mut File>) -> Result<usize>;
 }
 
-pub trait IntSeqDecoderIterator: Iterator<Item = u64> {
+pub trait IntSeqDecoderIterator<'a>: Iterator<Item = u64> {
     /// Creates a decoder
-    fn new_decoder(encoded_data: &[u8]) -> Self
+    fn new_decoder(encoded_data: &'a [u8]) -> Self
     where
         Self: Sized;
 

--- a/rs/index/src/index.rs
+++ b/rs/index/src/index.rs
@@ -3,8 +3,8 @@ use crate::utils::{IdWithScore, SearchContext};
 /// Main trait for index
 pub trait Searchable {
     /// Search for the nearest neighbors of a query vector
-    fn search(
-        &self,
+    fn search<'b>(
+        &'b self,
         query: &[f32],
         k: usize,
         ef_construction: u32,

--- a/rs/index/src/ivf/reader.rs
+++ b/rs/index/src/ivf/reader.rs
@@ -15,7 +15,7 @@ impl IvfReader {
         Self { base_directory }
     }
 
-    pub fn read<Q: Quantizer, D: IntSeqDecoderIterator>(&self) -> Result<Ivf<Q, D>> {
+    pub fn read<'a, Q: Quantizer, D: IntSeqDecoderIterator<'a>>(&self) -> Result<Ivf<'a, Q, D>> {
         let index_storage = FixedIndexFile::new(format!("{}/index", self.base_directory))?;
 
         let vector_storage_path = format!("{}/vectors", self.base_directory);
@@ -30,7 +30,7 @@ impl IvfReader {
         let quantizer_directory = format!("{}/quantizer", self.base_directory);
         let quantizer = Q::read(quantizer_directory).unwrap();
 
-        Ok(Ivf::<_, D>::new(
+        Ok(Ivf::<'_, _, D>::new(
             vector_storage,
             index_storage,
             num_clusters,

--- a/rs/index/src/posting_list/combined_file.rs
+++ b/rs/index/src/posting_list/combined_file.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::mem::size_of;
 
 use anyhow::{anyhow, Result};
@@ -26,8 +25,6 @@ pub struct Header {
 }
 
 pub struct FixedIndexFile {
-    _marker: PhantomData<u64>,
-
     mmap: Mmap,
     header: Header,
     doc_id_mapping_offset: usize,
@@ -52,7 +49,6 @@ impl FixedIndexFile {
             Self::align_to_next_boundary(centroid_offset + header.centroids_len as usize, 8)
                 + size_of::<u64>(); // FileBackedAppendablePostingListStorage's first u64 encodes num_clusters
         Ok(Self {
-            _marker: PhantomData,
             mmap,
             header,
             doc_id_mapping_offset,

--- a/rs/index/src/segment/immutable_segment.rs
+++ b/rs/index/src/segment/immutable_segment.rs
@@ -6,17 +6,17 @@ use crate::index::Searchable;
 use crate::spann::index::Spann;
 
 /// This is an immutable segment. This usually contains a single index.
-pub struct ImmutableSegment {
-    index: Spann,
+pub struct ImmutableSegment<'a> {
+    index: Spann<'a>,
 }
 
-impl ImmutableSegment {
-    pub fn new(index: Spann) -> Self {
+impl<'a> ImmutableSegment<'a> {
+    pub fn new(index: Spann<'a>) -> Self {
         Self { index }
     }
 }
 
-impl Segment for ImmutableSegment {
+impl<'a> Segment for ImmutableSegment<'a> {
     fn insert(&mut self, _doc_id: u64, _data: &[f32]) -> Result<()> {
         Err(anyhow!("ImmutableSegment does not support insertion"))
     }
@@ -32,7 +32,7 @@ impl Segment for ImmutableSegment {
     }
 }
 
-impl Searchable for ImmutableSegment {
+impl Searchable for ImmutableSegment<'_> {
     fn search(
         &self,
         query: &[f32],
@@ -44,6 +44,4 @@ impl Searchable for ImmutableSegment {
     }
 }
 
-impl SegmentSearchable for ImmutableSegment {}
-unsafe impl Send for ImmutableSegment {}
-unsafe impl Sync for ImmutableSegment {}
+impl SegmentSearchable for ImmutableSegment<'_> {}

--- a/rs/index/src/segment/immutable_segment.rs
+++ b/rs/index/src/segment/immutable_segment.rs
@@ -45,3 +45,5 @@ impl Searchable for ImmutableSegment {
 }
 
 impl SegmentSearchable for ImmutableSegment {}
+unsafe impl Send for ImmutableSegment {}
+unsafe impl Sync for ImmutableSegment {}

--- a/rs/index/src/spann/index.rs
+++ b/rs/index/src/spann/index.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 
+use compression::noc::noc::PlainDecoderIterator;
 use log::debug;
 use quantization::noq::noq::NoQuantizer;
 
@@ -9,11 +10,14 @@ use crate::ivf::index::Ivf;
 
 pub struct Spann {
     centroids: Hnsw<NoQuantizer>,
-    posting_lists: Ivf<NoQuantizer>,
+    posting_lists: Ivf<NoQuantizer, PlainDecoderIterator>,
 }
 
 impl Spann {
-    pub fn new(centroids: Hnsw<NoQuantizer>, posting_lists: Ivf<NoQuantizer>) -> Self {
+    pub fn new(
+        centroids: Hnsw<NoQuantizer>,
+        posting_lists: Ivf<NoQuantizer, PlainDecoderIterator>,
+    ) -> Self {
         Self {
             centroids,
             posting_lists,
@@ -24,7 +28,7 @@ impl Spann {
         &self.centroids
     }
 
-    pub fn get_posting_lists(&self) -> &Ivf<NoQuantizer> {
+    pub fn get_posting_lists(&self) -> &Ivf<NoQuantizer, PlainDecoderIterator> {
         &self.posting_lists
     }
 }

--- a/rs/index/src/spann/index.rs
+++ b/rs/index/src/spann/index.rs
@@ -8,15 +8,15 @@ use crate::hnsw::index::Hnsw;
 use crate::index::Searchable;
 use crate::ivf::index::Ivf;
 
-pub struct Spann {
+pub struct Spann<'a> {
     centroids: Hnsw<NoQuantizer>,
-    posting_lists: Ivf<NoQuantizer, PlainDecoderIterator>,
+    posting_lists: Ivf<'a, NoQuantizer, PlainDecoderIterator<'a>>,
 }
 
-impl Spann {
+impl<'a> Spann<'a> {
     pub fn new(
         centroids: Hnsw<NoQuantizer>,
-        posting_lists: Ivf<NoQuantizer, PlainDecoderIterator>,
+        posting_lists: Ivf<'a, NoQuantizer, PlainDecoderIterator<'a>>,
     ) -> Self {
         Self {
             centroids,
@@ -28,12 +28,12 @@ impl Spann {
         &self.centroids
     }
 
-    pub fn get_posting_lists(&self) -> &Ivf<NoQuantizer, PlainDecoderIterator> {
+    pub fn get_posting_lists(&self) -> &Ivf<'a, NoQuantizer, PlainDecoderIterator<'a>> {
         &self.posting_lists
     }
 }
 
-impl Searchable for Spann {
+impl Searchable for Spann<'_> {
     fn search(
         &self,
         query: &[f32],

--- a/rs/index/src/spann/reader.rs
+++ b/rs/index/src/spann/reader.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use compression::noc::noc::PlainDecoderIterator;
 use quantization::noq::noq::NoQuantizer;
 
 use super::index::Spann;
@@ -19,7 +20,8 @@ impl SpannReader {
         let centroid_path = format!("{}/centroids", self.base_directory);
 
         let centroids = HnswReader::new(centroid_path).read::<NoQuantizer>()?;
-        let posting_lists = IvfReader::new(posting_list_path).read::<NoQuantizer>()?;
+        let posting_lists =
+            IvfReader::new(posting_list_path).read::<NoQuantizer, PlainDecoderIterator>()?;
 
         Ok(Spann::new(centroids, posting_lists))
     }


### PR DESCRIPTION
Made quite some changes everywhere and it still doesn't compile
```
error[E0195]: lifetime parameters or bounds on method `search` do not match the trait declaration
   --> rs/index/src/ivf/index.rs:166:14
    |
166 |     fn search<'b>(
    |              ^^^^ lifetimes do not match method in trait
    |
   ::: rs/index/src/index.rs:6:14
    |
6   |     fn search<'b>(
    |              ---- lifetimes in impl do not match this method in trait

error[E0597]: `spann_reader` does not live long enough
  --> rs/index/src/collection/reader.rs:37:25
   |
33 |         let mut segments: Vec<Arc<BoxedSegmentSearchable>> = vec![];
   |                           -------------------------------- type annotation requires that `spann_reader` is borrowed for `'static`
...
36 |             let spann_reader = SpannReader::new(spann_path);
   |                 ------------ binding `spann_reader` declared here
37 |             let index = spann_reader.read()?;
   |                         ^^^^^^^^^^^^ borrowed value does not live long enough
38 |             segments.push(Arc::new(Box::new(ImmutableSegment::new(index))));
39 |         }
   |         - `spann_reader` dropped here while still borrowed

error[E0597]: `spann_reader` does not live long enough
   --> rs/index/src/collection/mod.rs:161:29
    |
159 |                 let spann_reader =
    |                     ------------ binding `spann_reader` declared here
160 |                     SpannReader::new(format!("{}/{}", self.base_directory, name_for_new_segment));
161 |                 let index = spann_reader.read()?;
    |                             ^^^^^^^^^^^^ borrowed value does not live long enough
162 |                 let segment: Arc<Box<dyn SegmentSearchable + Send + Sync>> =
163 |                     Arc::new(Box::new(ImmutableSegment::new(index)));
    |                              -------------------------------------- coercion requires that `spann_reader` is borrowed for `'static`
...
166 |             }
    |             - `spann_reader` dropped here while still borrowed
    |
    = note: due to object lifetime defaults, `Box<dyn SegmentSearchable + Send + Sync>` actually means `Box<(dyn SegmentSearchable + Send + Sync + 'static)>`
    ```