### PR TITLE
MultiSPANN writer and builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,6 +1388,7 @@ dependencies = [
  "log",
  "memmap2",
  "num-traits 0.2.19",
+ "odht",
  "ordered-float",
  "quantization",
  "rand 0.8.5",
@@ -1836,6 +1837,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "odht"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a518809ac14b25b569624d0268eba1e88498f71615893dca57982bed7621abb"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,4 @@ sorted-vec = "0.8.5"
 dashmap = "6.1.0"
 reqwest = {version = "0.12.11", features = ["json"]}
 atomic_refcell = "0.1.13"
+odht = "0.3.1"

--- a/rs/index/Cargo.toml
+++ b/rs/index/Cargo.toml
@@ -25,3 +25,4 @@ serde.workspace = true
 serde_json.workspace = true
 rayon.workspace = true
 atomic_refcell.workspace = true
+odht.workspace = true

--- a/rs/index/src/lib.rs
+++ b/rs/index/src/lib.rs
@@ -4,6 +4,7 @@ pub mod collection;
 pub mod hnsw;
 pub mod index;
 pub mod ivf;
+pub mod multi_spann;
 pub mod posting_list;
 pub mod segment;
 pub mod spann;

--- a/rs/index/src/multi_spann/builder.rs
+++ b/rs/index/src/multi_spann/builder.rs
@@ -1,0 +1,61 @@
+use std::sync::RwLock;
+
+use anyhow::Result;
+use dashmap::DashMap;
+
+use crate::spann::builder::{SpannBuilder, SpannBuilderConfig};
+
+pub struct MultiSpannBuilder {
+    config: SpannBuilderConfig,
+    inner_builders: DashMap<u64, RwLock<SpannBuilder>>,
+}
+
+impl MultiSpannBuilder {
+    pub fn new(config: SpannBuilderConfig) -> Result<Self> {
+        Ok(Self {
+            config,
+            inner_builders: DashMap::new(),
+        })
+    }
+
+    pub fn insert(&self, user_id: u64, doc_id: u64, data: &[f32]) -> Result<()> {
+        let spann_builder = self.inner_builders.entry(user_id).or_insert_with(|| {
+            let mut config = self.config.clone();
+            config.base_directory = format!("{}/{}", config.base_directory, user_id);
+            RwLock::new(SpannBuilder::new(config).unwrap())
+        });
+        spann_builder.write().unwrap().add(doc_id, data)?;
+        Ok(())
+    }
+
+    pub fn build(&self) -> Result<()> {
+        for entry in self.inner_builders.iter() {
+            entry.value().write().unwrap().build()?;
+        }
+        Ok(())
+    }
+
+    pub fn user_ids(&self) -> Vec<u64> {
+        self.inner_builders
+            .iter()
+            .map(|entry| *entry.key())
+            .collect()
+    }
+
+    pub fn base_directory(&self) -> &str {
+        &self.config.base_directory
+    }
+
+    /// This function will remove the builder for the given user id.
+    /// If the builder is not found, it will return None.
+    pub fn take_builder_for_user(&self, user_id: u64) -> Option<SpannBuilder> {
+        self.inner_builders
+            .remove(&user_id)
+            .map(|builder| builder.1.into_inner().unwrap())
+            .or(None)
+    }
+
+    pub fn config(&self) -> &SpannBuilderConfig {
+        &self.config
+    }
+}

--- a/rs/index/src/multi_spann/mod.rs
+++ b/rs/index/src/multi_spann/mod.rs
@@ -1,0 +1,3 @@
+pub mod builder;
+pub mod writer;
+pub mod user_index_info;

--- a/rs/index/src/multi_spann/user_index_info.rs
+++ b/rs/index/src/multi_spann/user_index_info.rs
@@ -1,0 +1,70 @@
+use odht::{Config, FxHashFn};
+
+#[derive(Clone)]
+pub struct UserIndexInfo {
+    pub user_id: u64,
+    pub centroid_vector_offset: u64,
+    pub centroid_vector_len: u64,
+    pub centroid_index_offset: u64,
+    pub centroid_index_len: u64,
+    pub ivf_vectors_offset: u64,
+    pub ivf_vectors_len: u64,
+    pub ivf_index_offset: u64,
+    pub ivf_index_len: u64,
+}
+
+impl UserIndexInfo {
+    #[inline]
+    pub fn to_le_bytes(&self) -> [u8; 72] {
+        let mut bytes = [0u8; 72];
+        bytes[0..8].copy_from_slice(&self.user_id.to_le_bytes());
+        bytes[8..16].copy_from_slice(&self.centroid_vector_offset.to_le_bytes());
+        bytes[16..24].copy_from_slice(&self.centroid_vector_len.to_le_bytes());
+        bytes[24..32].copy_from_slice(&self.centroid_index_offset.to_le_bytes());
+        bytes[32..40].copy_from_slice(&self.centroid_index_len.to_le_bytes());
+        bytes[40..48].copy_from_slice(&self.ivf_vectors_offset.to_le_bytes());
+        bytes[48..56].copy_from_slice(&self.ivf_vectors_len.to_le_bytes());
+        bytes[56..64].copy_from_slice(&self.ivf_index_offset.to_le_bytes());        
+        bytes[64..72].copy_from_slice(&self.ivf_index_len.to_le_bytes());
+        bytes
+    }
+
+    #[inline]
+    pub fn from_le_bytes(bytes: &[u8]) -> Self {
+        let user_id = u64::from_le_bytes(bytes[0..8].try_into().unwrap());
+        let centroid_vector_offset = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
+        let centroid_vector_len = u64::from_le_bytes(bytes[16..24].try_into().unwrap());
+        let centroid_index_offset = u64::from_le_bytes(bytes[24..32].try_into().unwrap());
+        let centroid_index_len = u64::from_le_bytes(bytes[32..40].try_into().unwrap());
+        let ivf_vectors_offset = u64::from_le_bytes(bytes[40..48].try_into().unwrap());
+        let ivf_vectors_len = u64::from_le_bytes(bytes[48..56].try_into().unwrap());
+        let ivf_index_offset = u64::from_le_bytes(bytes[56..64].try_into().unwrap());
+        let ivf_index_len = u64::from_le_bytes(bytes[64..72].try_into().unwrap());
+        Self {
+            user_id,
+            centroid_vector_offset,
+            centroid_vector_len,
+            centroid_index_offset,
+            centroid_index_len,
+            ivf_vectors_offset,
+            ivf_vectors_len,
+            ivf_index_offset,
+            ivf_index_len,
+        }
+    }
+}
+
+pub struct HashConfig {}
+impl Config for HashConfig {
+    type Key = u64;
+    type Value = UserIndexInfo;
+    type EncodedKey = [u8; 8];
+    type EncodedValue = [u8; 72];
+    type H = FxHashFn;
+
+    #[inline] fn encode_key(k: &Self::Key) -> Self::EncodedKey { k.to_le_bytes() }
+    #[inline] fn encode_value(v: &Self::Value) -> Self::EncodedValue { v.to_le_bytes() }
+    #[inline] fn decode_key(k: &Self::EncodedKey) -> Self::Key { u64::from_le_bytes(*k) }
+    #[inline] fn decode_value(v: &Self::EncodedValue) -> Self::Value { UserIndexInfo::from_le_bytes(v)}
+}
+

--- a/rs/index/src/multi_spann/writer.rs
+++ b/rs/index/src/multi_spann/writer.rs
@@ -1,0 +1,227 @@
+use std::fs::{self, File};
+use std::io::BufWriter;
+
+use anyhow::{Ok, Result};
+use odht::HashTableOwned;
+use quantization::noq::noq::{NoQuantizer, NoQuantizerWriter};
+use utils::distance::l2::L2DistanceCalculator;
+use utils::io::append_file_to_writer;
+
+use super::user_index_info::{HashConfig, UserIndexInfo};
+use crate::multi_spann::builder::MultiSpannBuilder;
+use crate::spann::writer::SpannWriter;
+
+pub struct MultiSpannWriter {
+    base_directory: String,
+}
+
+impl MultiSpannWriter {
+    pub fn new(base_directory: String) -> Self {
+        Self { base_directory }
+    }
+
+    pub fn write(&self, multi_spann: &mut MultiSpannBuilder) -> Result<Vec<UserIndexInfo>> {
+        let mut user_ids = multi_spann.user_ids();
+        user_ids.sort();
+        let base_directory = self.base_directory.clone();
+
+        // Build individual spanns
+        for user_id in user_ids.iter() {
+            let spann_directory = format!("{}/{}", base_directory, *user_id);
+            let spann_writer = SpannWriter::new(spann_directory);
+            let mut spann_builder = multi_spann.take_builder_for_user(*user_id).unwrap();
+            spann_writer.write(&mut spann_builder)?;
+        }
+
+        let mut user_index_infos = Vec::with_capacity(user_ids.len());
+        for user_id in user_ids.iter() {
+            user_index_infos.push(UserIndexInfo {
+                user_id: *user_id,
+                centroid_vector_offset: 0,
+                centroid_vector_len: 0,
+                centroid_index_offset: 0,
+                centroid_index_len: 0,
+                ivf_vectors_offset: 0,
+                ivf_vectors_len: 0,
+                ivf_index_offset: 0,
+                ivf_index_len: 0,
+            });
+        }
+
+        // Combine them
+        let centroids_directory = format!("{}/centroids", base_directory);
+        fs::create_dir_all(&centroids_directory)?;
+        let hnsw_directory = format!("{}/hnsw", centroids_directory);
+        fs::create_dir_all(&hnsw_directory)?;
+
+        let ivf_directory = format!("{}/ivf", base_directory);
+        fs::create_dir_all(&ivf_directory)?;
+
+        // Centroids index
+        let mut hnsw_index_file = File::create(format!("{}/index", hnsw_directory))?;
+        let mut hnsw_index_buffer_writer = BufWriter::new(&mut hnsw_index_file);
+
+        // Centroids vector file
+        let mut centroids_vector_file = File::create(format!("{}/vector_storage", hnsw_directory))?;
+        let mut centroids_vector_buffer_writer = BufWriter::new(&mut centroids_vector_file);
+
+        // IVF index file
+        let mut ivf_index_file = File::create(format!("{}/index", ivf_directory))?;
+        let mut ivf_index_buffer_writer = BufWriter::new(&mut ivf_index_file);
+
+        // IVF vectors file
+        let mut ivf_vectors_file = File::create(format!("{}/vectors", ivf_directory))?;
+        let mut ivf_vectors_buffer_writer = BufWriter::new(&mut ivf_vectors_file);
+
+        let mut centroids_index_written = 0;
+        let mut centroids_vector_written = 0;
+        let mut ivf_index_written = 0;
+        let mut ivf_vectors_written = 0;
+
+        for (idx, user_id) in user_ids.iter().enumerate() {
+            let user_id_base_directory = format!("{}/{}", base_directory, *user_id);
+            let user_id_index_file_path =
+                format!("{}/centroids/hnsw/index", user_id_base_directory);
+            let user_index_info = &mut user_index_infos[idx];
+
+            // Centroids index
+            user_index_info.centroid_index_offset = centroids_index_written;
+            centroids_index_written +=
+                append_file_to_writer(&user_id_index_file_path, &mut hnsw_index_buffer_writer)?
+                    as u64;
+            user_index_info.centroid_index_len =
+                centroids_index_written - user_index_info.centroid_index_offset;
+
+            // Centroids vector
+            user_index_info.centroid_vector_offset = centroids_vector_written;
+            centroids_vector_written += append_file_to_writer(
+                &format!("{}/centroids/hnsw/vector_storage", user_id_base_directory),
+                &mut centroids_vector_buffer_writer,
+            )? as u64;
+            user_index_info.centroid_vector_len =
+                centroids_vector_written - user_index_info.centroid_vector_offset;
+
+            // IVF index
+            user_index_info.ivf_index_offset = ivf_index_written;
+            ivf_index_written += append_file_to_writer(
+                &format!("{}/ivf/index", user_id_base_directory),
+                &mut ivf_index_buffer_writer,
+            )? as u64;
+            user_index_info.ivf_index_len = ivf_index_written - user_index_info.ivf_index_offset;
+
+            user_index_info.ivf_vectors_offset = ivf_vectors_written;
+            ivf_vectors_written += append_file_to_writer(
+                &format!("{}/ivf/vectors", user_id_base_directory),
+                &mut ivf_vectors_buffer_writer,
+            )? as u64;
+            user_index_info.ivf_vectors_len =
+                ivf_vectors_written - user_index_info.ivf_vectors_offset;
+        }
+
+        // Centroid quantizer
+        let centroid_quantizer_directory = format!("{}/quantizer", centroids_directory);
+        fs::create_dir_all(&centroid_quantizer_directory)?;
+        let num_features = multi_spann.config().num_features;
+        let no_quantizer = NoQuantizer::<L2DistanceCalculator>::new(num_features);
+        let quantizer_writer = NoQuantizerWriter::new(centroid_quantizer_directory);
+        quantizer_writer.write(&no_quantizer)?;
+
+        // IVF quantizer
+        let ivf_quantizer_directory = format!("{}/quantizer", ivf_directory);
+        fs::create_dir_all(&ivf_quantizer_directory)?;
+        let ivf_quantizer = NoQuantizer::<L2DistanceCalculator>::new(num_features);
+        let ivf_quantizer_writer = NoQuantizerWriter::new(ivf_quantizer_directory);
+        ivf_quantizer_writer.write(&ivf_quantizer)?;
+
+        // Write user index infos
+        let mut hash_table = HashTableOwned::<HashConfig>::with_capacity(user_ids.len(), 90);
+        for user_index_info in user_index_infos.iter() {
+            hash_table.insert(&user_index_info.user_id, &user_index_info);
+        }
+        let serialized = hash_table.raw_bytes();
+        let user_index_info_file = format!("{}/user_index_info", base_directory);
+        fs::write(&user_index_info_file, serialized)?;
+
+        // Cleanup the user directories
+        for user_id in user_ids.iter() {
+            let user_id_base_directory = format!("{}/{}", base_directory, *user_id);
+
+            // It's ok to fail for some reason
+            std::fs::remove_dir_all(user_id_base_directory).unwrap_or_default();
+        }
+
+        Ok(user_index_infos)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use tempdir::TempDir;
+    use utils::test_utils::generate_random_vector;
+
+    use super::*;
+    use crate::spann::builder::SpannBuilderConfig;
+
+    #[test]
+    fn test_write() {
+        let temp_dir = TempDir::new("test_write").unwrap();
+
+        let base_directory = temp_dir.path().to_str().unwrap().to_string();
+        let num_clusters = 10;
+        let num_vectors = 1000;
+        let num_features = 4;
+        let file_size = 4096;
+        let balance_factor = 0.0;
+        let max_posting_list_size = usize::MAX;
+        let mut builder = MultiSpannBuilder::new(SpannBuilderConfig {
+            max_neighbors: 10,
+            max_layers: 2,
+            ef_construction: 100,
+            vector_storage_memory_size: 1024,
+            vector_storage_file_size: file_size,
+            num_features,
+            max_iteration: 1000,
+            batch_size: 4,
+            num_clusters,
+            num_data_points_for_clustering: num_vectors,
+            max_clusters_per_vector: 1,
+            distance_threshold: 0.1,
+            base_directory: base_directory.clone(),
+            memory_size: 1024,
+            file_size,
+            tolerance: balance_factor,
+            max_posting_list_size,
+            reindex: false,
+        })
+        .unwrap();
+
+        // Generate 1000 vectors of f32, dimension 4
+        for i in 0..num_vectors {
+            builder
+                .insert(
+                    (i % 5) as u64,
+                    i as u64,
+                    &generate_random_vector(num_features),
+                )
+                .unwrap();
+        }
+        builder.build().unwrap();
+
+        let multi_spann_writer = MultiSpannWriter::new(base_directory.clone());
+        let user_index_infos = multi_spann_writer.write(&mut builder).unwrap();
+        assert_eq!(user_index_infos.len(), 5);
+
+        // Check if output directories and files exist
+        let centroids_directory_path = format!("{}/centroids/hnsw", base_directory);
+        let centroids_directory = PathBuf::from(&centroids_directory_path);
+        let hnsw_vector_storage_path =
+            format!("{}/vector_storage", centroids_directory.to_str().unwrap());
+        let hnsw_index_path = format!("{}/index", centroids_directory.to_str().unwrap());
+
+        assert!(PathBuf::from(&centroids_directory_path).exists());
+        assert!(PathBuf::from(&hnsw_vector_storage_path).exists());
+        assert!(PathBuf::from(&hnsw_index_path).exists());
+    }
+}

--- a/rs/index/src/segment/mutable_segment.rs
+++ b/rs/index/src/segment/mutable_segment.rs
@@ -1,4 +1,7 @@
+use std::sync::RwLock;
+
 use anyhow::{Ok, Result};
+use dashmap::DashMap;
 
 use crate::spann::builder::{SpannBuilder, SpannBuilderConfig};
 use crate::spann::writer::SpannWriter;
@@ -6,15 +9,20 @@ use crate::spann::writer::SpannWriter;
 pub struct MutableSegment {
     spann_builder: SpannBuilder,
 
+    spann_builder_per_user: DashMap<u64, RwLock<SpannBuilder>>,
+    config: SpannBuilderConfig,
+
     // Prevent a mutable segment from being modified after it is built.
     finalized: bool,
 }
 
 impl MutableSegment {
     pub fn new(config: SpannBuilderConfig) -> Result<Self> {
-        let spann_builder = SpannBuilder::new(config)?;
+        let spann_builder = SpannBuilder::new(config.clone())?;
         Ok(Self {
             spann_builder,
+            spann_builder_per_user: DashMap::new(),
+            config,
             finalized: false,
         })
     }
@@ -25,6 +33,19 @@ impl MutableSegment {
         }
 
         self.spann_builder.add(doc_id, data)
+    }
+
+    /// Insert a document for a user
+    pub fn insert_for_user(&self, user_id: u64, doc_id: u64, data: &[f32]) -> Result<()> {
+        if self.finalized {
+            return Err(anyhow::anyhow!("Cannot insert into a finalized segment"));
+        }
+
+        let spann_builder = self.spann_builder_per_user.entry(user_id).or_insert_with(|| {
+            RwLock::new(SpannBuilder::new(self.config.clone()).unwrap())
+        });
+        spann_builder.write().unwrap().add(doc_id, data)?;
+        Ok(())
     }
 
     pub fn build(&mut self, base_directory: String, name: String) -> Result<()> {


### PR DESCRIPTION
* We're going to have a SPANN index per user. In the writer, we will combine them all into a single file (for each of vector, index). That way we reduce number of files. 
* User index infos will contain the offset and length needed to find the slice of each user's index in the combined files.