### PR TITLE
Add an option to allow writing only config for PQ

### DIFF
--- a/rs/index/src/hnsw/reader.rs
+++ b/rs/index/src/hnsw/reader.rs
@@ -158,7 +158,9 @@ mod tests {
             pq_builder.add(datapoints[i].clone());
         }
         let pq = pq_builder.build(base_directory.clone()).unwrap();
-        assert!(pq.write_to_directory(&pq_dir).is_ok());
+        assert!(pq
+            .write_to_directory(&pq_dir, /*config_only*/ false)
+            .is_ok());
 
         // Create a HNSW Builder
         let vector_dir = format!("{}/vectors", base_directory);
@@ -196,7 +198,9 @@ mod tests {
         let quantizer = NoQuantizer::<L2DistanceCalculator>::new(128);
         let quantizer_dir = format!("{}/quantizer", base_directory);
         fs::create_dir_all(quantizer_dir.clone()).unwrap();
-        assert!(quantizer.write_to_directory(&quantizer_dir).is_ok());
+        assert!(quantizer
+            .write_to_directory(&quantizer_dir, /*config_only*/ false)
+            .is_ok());
 
         let mut hnsw_builder =
             HnswBuilder::new(10, 128, 20, 1024, 4096, 128, quantizer, vector_dir);

--- a/rs/index/src/hnsw/writer.rs
+++ b/rs/index/src/hnsw/writer.rs
@@ -522,7 +522,9 @@ mod tests {
             pq_builder.add(datapoints[i].clone());
         }
         let pq = pq_builder.build(base_directory.clone()).unwrap();
-        assert!(pq.write_to_directory(&pq_dir).is_ok());
+        assert!(pq
+            .write_to_directory(&pq_dir, /*config_only*/ false)
+            .is_ok());
 
         // Create a HNSW Builder
         let vector_dir = format!("{}/vectors", base_directory);

--- a/rs/index/src/ivf/reader.rs
+++ b/rs/index/src/ivf/reader.rs
@@ -97,7 +97,9 @@ mod tests {
         let quantizer_directory = format!("{}/quantizer", base_directory);
         std::fs::create_dir_all(&quantizer_directory)
             .expect("Failed to create quantizer directory");
-        assert!(quantizer.write_to_directory(&quantizer_directory).is_ok());
+        assert!(quantizer
+            .write_to_directory(&quantizer_directory, /*config_only*/ false)
+            .is_ok());
         let writer =
             IvfWriter::<_, EliasFano, L2DistanceCalculator>::new(base_directory.clone(), quantizer);
 
@@ -244,7 +246,7 @@ mod tests {
         std::fs::create_dir_all(&quantizer_directory_ref)
             .expect("Failed to create quantizer directory");
         assert!(quantizer
-            .write_to_directory(&quantizer_directory_ref)
+            .write_to_directory(&quantizer_directory_ref, /*config_only*/ false)
             .is_ok());
         let writer_ref = IvfWriter::<_, PlainEncoder, L2DistanceCalculator>::new(
             base_directory_ref.clone(),
@@ -254,7 +256,9 @@ mod tests {
         let quantizer_directory = format!("{}/quantizer", base_directory);
         std::fs::create_dir_all(&quantizer_directory)
             .expect("Failed to create quantizer directory");
-        assert!(quantizer.write_to_directory(&quantizer_directory).is_ok());
+        assert!(quantizer
+            .write_to_directory(&quantizer_directory, /*config_only*/ false)
+            .is_ok());
         let writer =
             IvfWriter::<_, EliasFano, L2DistanceCalculator>::new(base_directory.clone(), quantizer);
 
@@ -329,7 +333,9 @@ mod tests {
         let quantizer_directory = format!("{}/quantizer", base_directory);
         std::fs::create_dir_all(&quantizer_directory)
             .expect("Failed to create quantizer directory");
-        assert!(quantizer.write_to_directory(&quantizer_directory).is_ok());
+        assert!(quantizer
+            .write_to_directory(&quantizer_directory, /*config_only*/ false)
+            .is_ok());
         let writer = IvfWriter::<_, PlainEncoder, L2DistanceCalculator>::new(
             base_directory.clone(),
             quantizer,
@@ -365,7 +371,9 @@ mod tests {
         let quantizer_directory = format!("{}/quantizer", base_directory);
         std::fs::create_dir_all(&quantizer_directory)
             .expect("Failed to create quantizer directory");
-        assert!(quantizer.write_to_directory(&quantizer_directory).is_ok());
+        assert!(quantizer
+            .write_to_directory(&quantizer_directory, /*config_only*/ false)
+            .is_ok());
 
         let reader = IvfReader::new(base_directory.clone());
         let index = reader
@@ -473,7 +481,9 @@ mod tests {
         let quantizer_directory = format!("{}/quantizer", base_directory);
         std::fs::create_dir_all(&quantizer_directory)
             .expect("Failed to create quantizer directory");
-        assert!(quantizer.write_to_directory(&quantizer_directory).is_ok());
+        assert!(quantizer
+            .write_to_directory(&quantizer_directory, /*config_only*/ false)
+            .is_ok());
 
         let writer = IvfWriter::<_, PlainEncoder, L2DistanceCalculator>::new(
             base_directory.clone(),

--- a/rs/index/src/multi_spann/writer.rs
+++ b/rs/index/src/multi_spann/writer.rs
@@ -142,13 +142,14 @@ impl MultiSpannWriter {
         fs::create_dir_all(&centroid_quantizer_directory)?;
         let num_features = multi_spann.config().num_features;
         let no_quantizer = NoQuantizer::<L2DistanceCalculator>::new(num_features);
-        no_quantizer.write_to_directory(&centroid_quantizer_directory)?;
+        no_quantizer
+            .write_to_directory(&centroid_quantizer_directory, /*config_only*/ false)?;
 
         // IVF quantizer
         let ivf_quantizer_directory = format!("{}/quantizer", ivf_directory);
         fs::create_dir_all(&ivf_quantizer_directory)?;
         let ivf_quantizer = NoQuantizer::<L2DistanceCalculator>::new(num_features);
-        ivf_quantizer.write_to_directory(&ivf_quantizer_directory)?;
+        ivf_quantizer.write_to_directory(&ivf_quantizer_directory, /*config_only*/ false)?;
 
         // Write user index infos
         let mut hash_table = HashTableOwned::<HashConfig>::with_capacity(user_ids.len(), 90);

--- a/rs/index/src/spann/writer.rs
+++ b/rs/index/src/spann/writer.rs
@@ -67,7 +67,7 @@ impl SpannWriter {
 
         let ivf_quantizer_directory = format!("{}/quantizer", ivf_directory);
         std::fs::create_dir_all(&ivf_quantizer_directory)?;
-        pq.write_to_directory(&ivf_quantizer_directory)?;
+        pq.write_to_directory(&ivf_quantizer_directory, /*config_only*/ false)?;
 
         debug!("Writing IVF index");
         let ivf_writer =
@@ -87,7 +87,7 @@ impl SpannWriter {
         std::fs::create_dir_all(&ivf_quantizer_directory)?;
         let ivf_quantizer =
             NoQuantizer::<L2DistanceCalculator>::new(index_writer_config.num_features);
-        ivf_quantizer.write_to_directory(&ivf_quantizer_directory)?;
+        ivf_quantizer.write_to_directory(&ivf_quantizer_directory, /*config_only*/ false)?;
 
         debug!("Writing IVF index");
         let ivf_writer = IvfWriter::<_, PlainEncoder, L2DistanceCalculator>::new(
@@ -124,7 +124,7 @@ impl SpannWriter {
         spann_builder
             .centroid_builder
             .quantizer
-            .write_to_directory(&centroid_quantizer_directory)?;
+            .write_to_directory(&centroid_quantizer_directory, /*config_only*/ false)?;
 
         // Write posting lists
         let ivf_directory = format!("{}/ivf", self.base_directory);

--- a/rs/index_writer/src/index_writer.rs
+++ b/rs/index_writer/src/index_writer.rs
@@ -69,7 +69,7 @@ impl IndexWriter {
         std::fs::create_dir_all(&quantizer_directory)?;
 
         // Use the provided writer function to write the quantizer
-        quantizer.write_to_directory(&quantizer_directory)?;
+        quantizer.write_to_directory(&quantizer_directory, /*config_only*/ false)?;
 
         info!("Start building index");
         let vector_directory = format!("{}/vectors", path);
@@ -273,8 +273,9 @@ impl IndexWriter {
         let pq = pq_builder.build(format!("{}/pq_tmp", &self.output_root))?;
 
         // Define the writer function for ProductQuantizer
-        let pq_writer_fn =
-            |directory: &String, pq: &ProductQuantizer<D>| pq.write_to_directory(&directory);
+        let pq_writer_fn = |directory: &String, pq: &ProductQuantizer<D>| {
+            pq.write_to_directory(&directory, /*config_only*/ false)
+        };
 
         self.write_quantizer_and_build_ivf_index::<_, E, D, _>(
             input,
@@ -302,8 +303,9 @@ impl IndexWriter {
         let noq = noq_builder.build()?;
 
         // Define the writer function for NoQuantizer
-        let noq_writer_fn =
-            |directory: &String, noq: &NoQuantizer<D>| noq.write_to_directory(&directory);
+        let noq_writer_fn = |directory: &String, noq: &NoQuantizer<D>| {
+            noq.write_to_directory(&directory, /*config_only*/ false)
+        };
 
         self.write_quantizer_and_build_ivf_index::<_, E, D, _>(
             input,

--- a/rs/quantization/src/noq/noq.rs
+++ b/rs/quantization/src/noq/noq.rs
@@ -55,7 +55,7 @@ impl<D: DistanceCalculator> Quantizer for NoQuantizer<D> {
 }
 
 impl<D: DistanceCalculator> WritableQuantizer for NoQuantizer<D> {
-    fn write_to_directory(&self, base_directory: &str) -> Result<()> {
+    fn write_to_directory(&self, base_directory: &str, _config_only: bool) -> Result<()> {
         let config = NoQuantizerConfig {
             dimension: self.dimension,
         };

--- a/rs/quantization/src/quantization.rs
+++ b/rs/quantization/src/quantization.rs
@@ -38,5 +38,5 @@ pub trait Quantizer {
 }
 
 pub trait WritableQuantizer: Quantizer {
-    fn write_to_directory(&self, base_directory: &str) -> Result<()>;
+    fn write_to_directory(&self, base_directory: &str, config_only: bool) -> Result<()>;
 }


### PR DESCRIPTION
When writing quantizer in Multi-SPANN, we only need to write a common config (supposedly this is the same for all SPANNs), the codebook will be the combining of all SPANN codebooks