### PR TITLE
Segment optimizer framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,12 +1391,15 @@ dependencies = [
  "config",
  "dashmap",
  "env_logger",
+ "fs_extra",
  "kmeans",
+ "lock_api",
  "log",
  "memmap2",
  "num-traits 0.2.19",
  "odht",
  "ordered-float",
+ "parking_lot",
  "quantization",
  "rand 0.8.5",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,6 @@ dashmap = "6.1.0"
 reqwest = {version = "0.12.11", features = ["json"]}
 atomic_refcell = "0.1.13"
 odht = "0.3.1"
+parking_lot = "0.12.3"
+lock_api = "0.4.12"
+fs_extra = "1.3.0"

--- a/rs/index/Cargo.toml
+++ b/rs/index/Cargo.toml
@@ -28,3 +28,7 @@ serde_yaml.workspace = true
 rayon.workspace = true
 atomic_refcell.workspace = true
 odht.workspace = true
+parking_lot.workspace = true
+lock_api.workspace = true
+fs_extra.workspace = true
+

--- a/rs/index/src/collection/snapshot.rs
+++ b/rs/index/src/collection/snapshot.rs
@@ -1,19 +1,20 @@
 use std::sync::Arc;
 
-use super::{BoxedSegmentSearchable, Collection};
+use super::Collection;
 use crate::index::Searchable;
+use crate::segment::BoxedImmutableSegment;
 use crate::utils::{IdWithScore, SearchContext};
 
 /// Snapshot provides a view of the collection at a given point in time
 pub struct Snapshot {
-    pub segments: Vec<Arc<BoxedSegmentSearchable>>,
+    pub segments: Vec<BoxedImmutableSegment>,
     pub version: u64,
     pub collection: Arc<Collection>,
 }
 
 impl Snapshot {
     pub fn new(
-        segments: Vec<Arc<BoxedSegmentSearchable>>,
+        segments: Vec<BoxedImmutableSegment>,
         version: u64,
         collection: Arc<Collection>,
     ) -> Self {

--- a/rs/index/src/lib.rs
+++ b/rs/index/src/lib.rs
@@ -5,6 +5,7 @@ pub mod hnsw;
 pub mod index;
 pub mod ivf;
 pub mod multi_spann;
+pub mod optimizers;
 pub mod posting_list;
 pub mod segment;
 pub mod spann;

--- a/rs/index/src/optimizers/engine.rs
+++ b/rs/index/src/optimizers/engine.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use super::noop::NoopOptimizer;
+use crate::collection::Collection;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum OptimizingType {
+    Vacuum,
+    Merge,
+    Noop,
+}
+
+pub struct OptimizerEngine {
+    collection: Arc<Collection>,
+}
+
+impl OptimizerEngine {
+    pub fn new(collection: Arc<Collection>) -> Self {
+        Self { collection }
+    }
+
+    pub fn run(&self, segments: Vec<String>, optimizing_type: OptimizingType) -> Result<()> {
+        if segments.len() < 2 && optimizing_type == OptimizingType::Merge {
+            return Ok(());
+        }
+
+        let pending_segment = self.collection.init_optimizing(&segments)?;
+        match optimizing_type {
+            OptimizingType::Vacuum => Ok(()),
+            OptimizingType::Merge => Ok(()),
+            OptimizingType::Noop => {
+                let noop_optimizer = NoopOptimizer::new();
+                self.collection
+                    .run_optimizer(&noop_optimizer, &pending_segment)?;
+                Ok(())
+            }
+        }
+    }
+}

--- a/rs/index/src/optimizers/mod.rs
+++ b/rs/index/src/optimizers/mod.rs
@@ -1,0 +1,11 @@
+pub mod engine;
+pub mod noop;
+
+use anyhow::Result;
+use quantization::quantization::Quantizer;
+
+use crate::segment::pending_segment::PendingSegment;
+
+pub trait SegmentOptimizer {
+    fn optimize<Q: Quantizer>(&self, segment: &PendingSegment<Q>) -> Result<()>;
+}

--- a/rs/index/src/optimizers/noop.rs
+++ b/rs/index/src/optimizers/noop.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+use fs_extra::dir::CopyOptions;
+use quantization::quantization::Quantizer;
+
+use super::SegmentOptimizer;
+use crate::segment::pending_segment::PendingSegment;
+use crate::segment::Segment;
+
+pub struct NoopOptimizer;
+
+/// This optimizer does nothing. It just copies the original segment to a new segment.
+/// Useful for testing the optimizer framework.
+impl NoopOptimizer {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+/// This optimizer does nothing. It just copies the original segment to a new segment.
+impl SegmentOptimizer for NoopOptimizer {
+    fn optimize<Q: Quantizer>(&self, segment: &PendingSegment<Q>) -> Result<()> {
+        let inner_segments = segment.inner_segments();
+        let data_directory = segment.base_directory();
+
+        // Recursively copy everything from the data directory's inner segments to the new data directory.
+        for inner_segment in inner_segments {
+            let inner_segment_path = format!("{}/{}", data_directory, inner_segment);
+            let pending_segment_path = format!("{}/{}", data_directory, segment.name());
+
+            // Ignore errors if we can't create the directory. It might already exist.
+            std::fs::create_dir_all(pending_segment_path.clone()).unwrap_or_default();
+
+            // Copy the inner segment's contents to the new data directory
+            let mut options = CopyOptions::default();
+            options.content_only = true; // This ensures we copy only the contents, not the directory itself
+            fs_extra::dir::copy(inner_segment_path, pending_segment_path, &options)?;
+        }
+        Ok(())
+    }
+}

--- a/rs/index/src/segment/immutable_segment.rs
+++ b/rs/index/src/segment/immutable_segment.rs
@@ -9,27 +9,36 @@ use crate::multi_spann::index::MultiSpannIndex;
 /// This is an immutable segment. This usually contains a single index.
 pub struct ImmutableSegment<Q: Quantizer> {
     index: MultiSpannIndex<Q>,
+    name: String,
 }
 
 impl<Q: Quantizer> ImmutableSegment<Q> {
-    pub fn new(index: MultiSpannIndex<Q>) -> Self {
-        Self { index }
+    pub fn new(index: MultiSpannIndex<Q>, name: String) -> Self {
+        Self { index, name }
     }
 }
 
+/// This is the implementation of Segment for ImmutableSegment.
 impl<Q: Quantizer> Segment for ImmutableSegment<Q> {
-    fn insert(&mut self, _doc_id: u64, _data: &[f32]) -> Result<()> {
+    /// ImmutableSegment does not support insertion.
+    fn insert(&self, _doc_id: u64, _data: &[f32]) -> Result<()> {
         Err(anyhow!("ImmutableSegment does not support insertion"))
     }
 
-    fn remove(&mut self, _doc_id: u64) -> Result<bool> {
+    /// ImmutableSegment does not support removal.
+    fn remove(&self, _doc_id: u64) -> Result<bool> {
         // TODO(hicder): Implement this
         Ok(false)
     }
 
+    /// ImmutableSegment does not support contains.
     fn may_contains(&self, _doc_id: u64) -> bool {
         // TODO(hicder): Implement this
         return true;
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
     }
 }
 

--- a/rs/index/src/segment/mod.rs
+++ b/rs/index/src/segment/mod.rs
@@ -1,7 +1,18 @@
 pub mod immutable_segment;
 pub mod mutable_segment;
+pub mod pending_segment;
+
+use std::sync::Arc;
 
 use anyhow::Result;
+use immutable_segment::ImmutableSegment;
+use parking_lot::RwLock;
+use pending_segment::PendingSegment;
+use quantization::noq::noq::NoQuantizerL2;
+use quantization::pq::pq::ProductQuantizerL2;
+
+use crate::index::Searchable;
+use crate::utils::{IdWithScore, SearchContext};
 
 /// A segment is a partial index: users can insert some documents, then flush
 /// the containing collection, to effectively create a segment.
@@ -9,14 +20,221 @@ pub trait Segment {
     /// Inserts a document into the segment.
     /// Returns an error if the insertion process fails for any reason.
     /// NOTE: Some type of segment may not support insertion.
-    fn insert(&mut self, doc_id: u64, data: &[f32]) -> Result<()>;
+    fn insert(&self, doc_id: u64, data: &[f32]) -> Result<()>;
 
     /// Removes a document from the segment.
     /// Returns true if the document was removed, false if the document was not found.
     /// Returns an error if the removal process fails for any reason.
-    fn remove(&mut self, doc_id: u64) -> Result<bool>;
+    fn remove(&self, doc_id: u64) -> Result<bool>;
 
     /// Returns true if the segment may contain the given document.
     /// False if the segment definitely does not contain the document.
     fn may_contains(&self, doc_id: u64) -> bool;
+
+    /// Returns the name of the segment.
+    fn name(&self) -> String;
+}
+
+// TODO(hicder): Add different types of distance
+#[derive(Clone)]
+pub enum BoxedImmutableSegment {
+    FinalizedNoQuantizationSegment(Arc<RwLock<ImmutableSegment<NoQuantizerL2>>>),
+    FinalizedProductQuantizationSegment(Arc<RwLock<ImmutableSegment<ProductQuantizerL2>>>),
+
+    PendingNoQuantizationSegment(Arc<RwLock<PendingSegment<NoQuantizerL2>>>),
+    PendingProductQuantizationSegment(Arc<RwLock<PendingSegment<ProductQuantizerL2>>>),
+
+    // For tests
+    MockedNoQuantizationSegment(Arc<RwLock<MockedSegment>>),
+}
+
+impl Searchable for BoxedImmutableSegment {
+    fn search(
+        &self,
+        query: &[f32],
+        k: usize,
+        ef_construction: u32,
+        context: &mut crate::utils::SearchContext,
+    ) -> Option<Vec<crate::utils::IdWithScore>> {
+        self.search_with_id(0u128, query, k, ef_construction, context)
+    }
+
+    fn search_with_id(
+        &self,
+        id: u128,
+        query: &[f32],
+        k: usize,
+        ef_construction: u32,
+        context: &mut SearchContext,
+    ) -> Option<Vec<IdWithScore>> {
+        match self {
+            BoxedImmutableSegment::FinalizedNoQuantizationSegment(immutable_segment) => {
+                immutable_segment
+                    .read()
+                    .search_with_id(id, query, k, ef_construction, context)
+            }
+            BoxedImmutableSegment::FinalizedProductQuantizationSegment(immutable_segment) => {
+                immutable_segment
+                    .read()
+                    .search_with_id(id, query, k, ef_construction, context)
+            }
+            BoxedImmutableSegment::MockedNoQuantizationSegment(mocked_segment) => mocked_segment
+                .read()
+                .search_with_id(id, query, k, ef_construction, context),
+            BoxedImmutableSegment::PendingNoQuantizationSegment(pending_segment) => pending_segment
+                .read()
+                .search_with_id(id, query, k, ef_construction, context),
+            BoxedImmutableSegment::PendingProductQuantizationSegment(pending_segment) => {
+                pending_segment
+                    .read()
+                    .search_with_id(id, query, k, ef_construction, context)
+            }
+        }
+    }
+}
+
+impl Segment for BoxedImmutableSegment {
+    fn insert(&self, doc_id: u64, data: &[f32]) -> Result<()> {
+        match self {
+            BoxedImmutableSegment::FinalizedNoQuantizationSegment(immutable_segment) => {
+                immutable_segment.write().insert(doc_id, data)
+            }
+            BoxedImmutableSegment::FinalizedProductQuantizationSegment(immutable_segment) => {
+                immutable_segment.write().insert(doc_id, data)
+            }
+            BoxedImmutableSegment::MockedNoQuantizationSegment(mocked_segment) => {
+                mocked_segment.write().insert(doc_id, data)
+            }
+            BoxedImmutableSegment::PendingNoQuantizationSegment(pending_segment) => {
+                pending_segment.write().insert(doc_id, data)
+            }
+            BoxedImmutableSegment::PendingProductQuantizationSegment(pending_segment) => {
+                pending_segment.write().insert(doc_id, data)
+            }
+        }
+    }
+
+    fn remove(&self, doc_id: u64) -> Result<bool> {
+        match self {
+            BoxedImmutableSegment::FinalizedNoQuantizationSegment(immutable_segment) => {
+                immutable_segment.read().remove(doc_id)
+            }
+            BoxedImmutableSegment::FinalizedProductQuantizationSegment(immutable_segment) => {
+                immutable_segment.read().remove(doc_id)
+            }
+            BoxedImmutableSegment::MockedNoQuantizationSegment(mocked_segment) => {
+                mocked_segment.read().remove(doc_id)
+            }
+            BoxedImmutableSegment::PendingNoQuantizationSegment(pending_segment) => {
+                pending_segment.read().remove(doc_id)
+            }
+            BoxedImmutableSegment::PendingProductQuantizationSegment(pending_segment) => {
+                pending_segment.read().remove(doc_id)
+            }
+        }
+    }
+
+    fn may_contains(&self, doc_id: u64) -> bool {
+        match self {
+            BoxedImmutableSegment::FinalizedNoQuantizationSegment(immutable_segment) => {
+                immutable_segment.read().may_contains(doc_id)
+            }
+            BoxedImmutableSegment::FinalizedProductQuantizationSegment(immutable_segment) => {
+                immutable_segment.read().may_contains(doc_id)
+            }
+            BoxedImmutableSegment::MockedNoQuantizationSegment(mocked_segment) => {
+                mocked_segment.read().may_contains(doc_id)
+            }
+            BoxedImmutableSegment::PendingNoQuantizationSegment(pending_segment) => {
+                pending_segment.read().may_contains(doc_id)
+            }
+            BoxedImmutableSegment::PendingProductQuantizationSegment(pending_segment) => {
+                pending_segment.read().may_contains(doc_id)
+            }
+        }
+    }
+
+    fn name(&self) -> String {
+        match self {
+            BoxedImmutableSegment::FinalizedNoQuantizationSegment(immutable_segment) => {
+                immutable_segment.read().name()
+            }
+            BoxedImmutableSegment::FinalizedProductQuantizationSegment(immutable_segment) => {
+                immutable_segment.read().name()
+            }
+            BoxedImmutableSegment::PendingNoQuantizationSegment(pending_segment) => {
+                pending_segment.read().name()
+            }
+            BoxedImmutableSegment::PendingProductQuantizationSegment(pending_segment) => {
+                pending_segment.read().name()
+            }
+            BoxedImmutableSegment::MockedNoQuantizationSegment(mocked_segment) => {
+                mocked_segment.read().name()
+            }
+        }
+    }
+}
+
+unsafe impl Send for BoxedImmutableSegment {}
+unsafe impl Sync for BoxedImmutableSegment {}
+
+pub struct MockedSegment {
+    name: String,
+    ids_to_return: Vec<u128>,
+}
+
+impl MockedSegment {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            ids_to_return: vec![],
+        }
+    }
+
+    pub fn set_ids_to_return(&mut self, ids_to_return: Vec<u128>) {
+        self.ids_to_return = ids_to_return;
+    }
+}
+
+#[allow(unused)]
+impl Searchable for MockedSegment {
+    fn search(
+        &self,
+        query: &[f32],
+        k: usize,
+        ef_construction: u32,
+        context: &mut crate::utils::SearchContext,
+    ) -> Option<Vec<crate::utils::IdWithScore>> {
+        todo!()
+    }
+
+    fn search_with_id(
+        &self,
+        id: u128,
+        query: &[f32],
+        k: usize,
+        ef_construction: u32,
+        context: &mut crate::utils::SearchContext,
+    ) -> Option<Vec<crate::utils::IdWithScore>> {
+        todo!()
+    }
+}
+
+#[allow(unused)]
+impl Segment for MockedSegment {
+    fn insert(&self, doc_id: u64, data: &[f32]) -> Result<()> {
+        todo!()
+    }
+
+    fn remove(&self, doc_id: u64) -> Result<bool> {
+        todo!()
+    }
+
+    fn may_contains(&self, doc_id: u64) -> bool {
+        todo!()
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
 }

--- a/rs/index/src/segment/pending_segment.rs
+++ b/rs/index/src/segment/pending_segment.rs
@@ -1,0 +1,212 @@
+use std::path::PathBuf;
+
+use anyhow::{Ok, Result};
+use parking_lot::RwLock;
+use quantization::quantization::Quantizer;
+
+use super::{BoxedImmutableSegment, Segment};
+use crate::index::Searchable;
+use crate::multi_spann::index::MultiSpannIndex;
+use crate::multi_spann::reader::MultiSpannReader;
+use crate::utils::{IdWithScore, SearchContext};
+
+pub struct PendingSegment<Q: Quantizer> {
+    inner_segments: Vec<BoxedImmutableSegment>,
+    inner_segments_names: Vec<String>,
+    name: String,
+    parent_directory: String,
+
+    // Whether to use the internal index instead of passing the query to inner segments.
+    // Invariant: use_internal_index is true if and only if index is Some.
+    use_internal_index: bool,
+
+    // The internal index.
+    index: RwLock<Option<MultiSpannIndex<Q>>>,
+}
+
+impl<Q: Quantizer> PendingSegment<Q> {
+    pub fn new(inner_segments: Vec<BoxedImmutableSegment>, data_directory: String) -> Self {
+        let path = PathBuf::from(&data_directory);
+        // name is the last portion of the data_directory
+        let name = path.file_name().unwrap().to_str().unwrap().to_string();
+
+        // base directory is the directory of the data_directory
+        let parent_directory = path.parent().unwrap().to_str().unwrap().to_string();
+        let inner_segments_names = inner_segments
+            .iter()
+            .map(|segment| segment.name())
+            .collect();
+
+        Self {
+            inner_segments,
+            inner_segments_names,
+            name,
+            parent_directory,
+            index: RwLock::new(None),
+            use_internal_index: false,
+        }
+    }
+
+    // Caller must hold the read lock before calling this function.
+    pub fn build_index(&self) -> Result<()> {
+        let current_directory = format!("{}/{}", self.parent_directory, self.name);
+        let reader = MultiSpannReader::new(current_directory);
+        let index = reader.read::<Q>()?;
+        self.index.write().replace(index);
+        Ok(())
+    }
+
+    // Caller must hold the write lock before calling this function.
+    pub fn apply_pending_deletions(&self) -> Result<()> {
+        // TODO(hicder): Implement this once we support deletions.
+        Ok(())
+    }
+
+    // Caller must hold the write lock before calling this function.
+    pub fn switch_to_internal_index(&mut self) {
+        self.use_internal_index = true;
+    }
+
+    pub fn inner_segments(&self) -> &Vec<String> {
+        &self.inner_segments_names
+    }
+
+    pub fn base_directory(&self) -> &String {
+        &self.parent_directory
+    }
+}
+
+#[allow(unused)]
+impl<Q: Quantizer> Segment for PendingSegment<Q> {
+    fn insert(&self, doc_id: u64, data: &[f32]) -> Result<()> {
+        Err(anyhow::anyhow!("Pending segment does not support insert"))
+    }
+
+    fn remove(&self, _doc_id: u64) -> Result<bool> {
+        todo!()
+    }
+
+    fn may_contains(&self, _doc_id: u64) -> bool {
+        todo!()
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+}
+
+impl<Q: Quantizer> Searchable for PendingSegment<Q> {
+    fn search(
+        &self,
+        query: &[f32],
+        k: usize,
+        ef_construction: u32,
+        context: &mut SearchContext,
+    ) -> Option<Vec<IdWithScore>> {
+        self.search_with_id(0, query, k, ef_construction, context)
+    }
+
+    fn search_with_id(
+        &self,
+        id: u128,
+        query: &[f32],
+        k: usize,
+        ef_construction: u32,
+        context: &mut SearchContext,
+    ) -> Option<Vec<IdWithScore>> {
+        if !self.use_internal_index {
+            let mut results = Vec::new();
+            for segment in &self.inner_segments {
+                let segment_result = segment.search_with_id(id, query, k, ef_construction, context);
+                if let Some(result) = segment_result {
+                    results.extend(result);
+                }
+            }
+            Some(results)
+        } else {
+            let index = self.index.read();
+            match &*index {
+                Some(index) => index.search_with_id(id, query, k, ef_construction, context),
+                None => None,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use config::collection::CollectionConfig;
+    use quantization::noq::noq::NoQuantizerL2;
+    use rand::Rng;
+
+    use super::*;
+    use crate::multi_spann::builder::MultiSpannBuilder;
+    use crate::multi_spann::writer::MultiSpannWriter;
+    use crate::segment::immutable_segment::ImmutableSegment;
+
+    fn build_segment(base_directory: String, starting_doc_id: u128) -> Result<()> {
+        let mut starting_doc_id = starting_doc_id;
+        let mut spann_builder_config = CollectionConfig::default_test_config();
+        spann_builder_config.num_features = 4;
+        let mut multi_spann_builder =
+            MultiSpannBuilder::new(spann_builder_config, base_directory.clone())?;
+
+        multi_spann_builder.insert(starting_doc_id % 2, starting_doc_id, &[1.0, 2.0, 3.0, 4.0])?;
+        starting_doc_id += 1;
+        multi_spann_builder.insert(starting_doc_id % 2, starting_doc_id, &[5.0, 6.0, 7.0, 8.0])?;
+        starting_doc_id += 1;
+        multi_spann_builder.insert(
+            starting_doc_id % 2,
+            starting_doc_id,
+            &[9.0, 10.0, 11.0, 12.0],
+        )?;
+        multi_spann_builder.build()?;
+
+        let multi_spann_writer = MultiSpannWriter::new(base_directory.clone());
+        multi_spann_writer.write(&mut multi_spann_builder)?;
+        Ok(())
+    }
+
+    fn read_segment(base_directory: String) -> Result<MultiSpannIndex<NoQuantizerL2>> {
+        let reader = MultiSpannReader::new(base_directory);
+        let index = reader.read::<NoQuantizerL2>()?;
+        Ok(index)
+    }
+
+    #[test]
+    fn test_pending_segment() -> Result<()> {
+        // temp directory
+        let tmp_dir = tempdir::TempDir::new("pending_segment_test").unwrap();
+        let base_dir = tmp_dir.path().to_str().unwrap().to_string();
+
+        // Create dir for segment1
+        let segment1_dir = format!("{}/segment_1", base_dir);
+        std::fs::create_dir_all(segment1_dir.clone()).unwrap();
+        build_segment(segment1_dir.clone(), 0)?;
+        let segment1 = read_segment(segment1_dir.clone())?;
+        let segment1 = BoxedImmutableSegment::FinalizedNoQuantizationSegment(Arc::new(
+            RwLock::new(ImmutableSegment::new(segment1, "segment_1".to_string())),
+        ));
+
+        let random_name = format!(
+            "pending_segment_{}",
+            rand::thread_rng().gen_range(0..1000000)
+        );
+        let pending_dir = format!("{}/{}", base_dir, random_name);
+        std::fs::create_dir_all(pending_dir.clone()).unwrap();
+
+        // Create a pending segment
+        let pending_segment =
+            PendingSegment::<NoQuantizerL2>::new(vec![segment1], pending_dir.clone());
+
+        let mut context = SearchContext::new(false);
+        let results = pending_segment.search_with_id(0, &[1.0, 2.0, 3.0, 4.0], 1, 10, &mut context);
+        let res = results.unwrap();
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].id, 0);
+
+        Ok(())
+    }
+}

--- a/rs/index_server/src/index_server.rs
+++ b/rs/index_server/src/index_server.rs
@@ -6,9 +6,10 @@ use index::utils::SearchContext;
 use log::info;
 use proto::muopdb::index_server_server::IndexServer;
 use proto::muopdb::{
-    CreateCollectionRequest, CreateCollectionResponse, FlushRequest, FlushResponse,
-    GetSegmentsRequest, GetSegmentsResponse, InsertPackedRequest, InsertPackedResponse,
-    InsertRequest, InsertResponse, SearchRequest, SearchResponse, CompactSegmentsRequest, CompactSegmentsResponse,
+    CompactSegmentsRequest, CompactSegmentsResponse, CreateCollectionRequest,
+    CreateCollectionResponse, FlushRequest, FlushResponse, GetSegmentsRequest, GetSegmentsResponse,
+    InsertPackedRequest, InsertPackedResponse, InsertRequest, InsertResponse, SearchRequest,
+    SearchResponse,
 };
 use tokio::sync::Mutex;
 use utils::mem::{lows_and_highs_to_u128s, transmute_u8_to_slice, u128s_to_lows_highs};
@@ -433,10 +434,15 @@ impl IndexServer for IndexServerImpl {
                 }
 
                 // TODO- khoa165: Logic to compact segments here
-                
+
                 let end = std::time::Instant::now();
                 let duration = end.duration_since(start);
-                info!("[{}] Compacted {} segments in {:?}", collection_name, segment_names.len(), duration);
+                info!(
+                    "[{}] Compacted {} segments in {:?}",
+                    collection_name,
+                    segment_names.len(),
+                    duration
+                );
 
                 Ok(tonic::Response::new(CompactSegmentsResponse {}))
             }

--- a/rs/quantization/src/noq/noq.rs
+++ b/rs/quantization/src/noq/noq.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use utils::distance::l2::L2DistanceCalculator;
 use utils::DistanceCalculator;
 
 use crate::quantization::{Quantizer, WritableQuantizer};
@@ -94,3 +95,5 @@ impl<D: DistanceCalculator> NoQuantizerReader<D> {
         Ok(NoQuantizer::new(config.dimension))
     }
 }
+
+pub type NoQuantizerL2 = NoQuantizer<L2DistanceCalculator>;

--- a/rs/quantization/src/pq/pq.rs
+++ b/rs/quantization/src/pq/pq.rs
@@ -369,3 +369,5 @@ mod tests {
         assert_eq!(new_pq.num_bits, 1);
     }
 }
+
+pub type ProductQuantizerL2 = ProductQuantizer<L2DistanceCalculator>;


### PR DESCRIPTION
This builds the framework to hook vacuum and merge optimizer into collection. In this PR, we introduce 2 main classes:
* `PendingSegment` - this will wrap the list of segments currently under optimizing
* `SegmentOptimizer` - this is the trait for vacuum and merge optimizer. Right now we only have `NoopOptimizer` which just duplicates the current inner segment and replace it.
* In `Collection`, we introduce a few more APIs. Caller will call like this
```
        let optimizer = NoopOptimizer::new();

        let pending_segment = collection.init_optimizing(&segment_names)?;
        collection.run_optimizer(&optimizer, &pending_segment)?;
```