### PR TITLE
Read pending segment on startup

### DIFF
--- a/rs/index/src/segment/pending_segment.rs
+++ b/rs/index/src/segment/pending_segment.rs
@@ -49,6 +49,11 @@ impl<Q: Quantizer> PendingSegment<Q> {
 
     // Caller must hold the read lock before calling this function.
     pub fn build_index(&self) -> Result<()> {
+        if self.use_internal_index {
+            // We shouldn't build the index if it already exists.
+            return Err(anyhow::anyhow!("Index already exists"));
+        }
+
         let current_directory = format!("{}/{}", self.parent_directory, self.name);
         let reader = MultiSpannReader::new(current_directory);
         let index = reader.read::<Q>()?;


### PR DESCRIPTION
As tilted. On startup, we clear the pending directory and read anew. 

In the future, once we support deletion, we need to spare the pending deletion list.