### PR TITLE
Write into WAL on insertion

### DIFF
--- a/rs/config/src/collection.rs
+++ b/rs/config/src/collection.rs
@@ -112,6 +112,15 @@ pub struct CollectionConfig {
     /// increased build time.
     /// Default: true
     pub reindex: bool,
+
+    /// The size of the WAL file.
+    /// Default: 0 (not using WAL)
+    #[serde(default = "default_wal_file_size")]
+    pub wal_file_size: u64,
+}
+
+fn default_wal_file_size() -> u64 {
+    0
 }
 
 impl Default for CollectionConfig {
@@ -139,6 +148,7 @@ impl Default for CollectionConfig {
             max_posting_list_size: usize::MAX,
             posting_list_kmeans_unbalanced_penalty: 0.0,
             reindex: true,
+            wal_file_size: 0,
         }
     }
 }
@@ -168,6 +178,7 @@ impl CollectionConfig {
             posting_list_kmeans_unbalanced_penalty: 0.1,
             reindex: true,
             quantization_type: QuantizerType::NoQuantizer,
+            wal_file_size: 1024 * 1024 * 1024,
         }
     }
 }

--- a/rs/index/src/collection/mod.rs
+++ b/rs/index/src/collection/mod.rs
@@ -93,7 +93,10 @@ impl Collection {
 
         let wal = if segment_config.wal_file_size > 0 {
             let wal_directory = format!("{}/wal", base_directory);
-            Some(RwLock::new(Wal::open(&wal_directory, segment_config.wal_file_size)?))
+            Some(RwLock::new(Wal::open(
+                &wal_directory,
+                segment_config.wal_file_size,
+            )?))
         } else {
             None
         };
@@ -160,7 +163,10 @@ impl Collection {
 
         let wal = if segment_config.wal_file_size > 0 {
             let wal_directory = format!("{}/wal", base_directory);
-            Some(RwLock::new(Wal::open(&wal_directory, segment_config.wal_file_size)?))
+            Some(RwLock::new(Wal::open(
+                &wal_directory,
+                segment_config.wal_file_size,
+            )?))
         } else {
             None
         };

--- a/rs/index/src/wal/entry.rs
+++ b/rs/index/src/wal/entry.rs
@@ -1,4 +1,31 @@
+use utils::mem::transmute_u8_to_slice;
+
+#[derive(Debug, Clone)]
 pub struct WalEntry {
     pub buffer: Vec<u8>,
     pub seq_no: u64,
+}
+
+pub struct WalEntryDecoded<'a> {
+    pub doc_ids: &'a [u128],
+    pub user_ids: &'a [u128],
+    pub data: &'a [f32],
+}
+
+impl WalEntry {
+    pub fn decode(&self, num_features: usize) -> WalEntryDecoded {
+        let length = self.buffer.len();
+        let num_vectors = length / (16 + 16 + 4 * num_features);
+        let doc_ids = transmute_u8_to_slice::<u128>(&self.buffer[0..num_vectors * 16]);
+        let user_ids = transmute_u8_to_slice::<u128>(
+            &self.buffer[num_vectors * 16..num_vectors * 16 + num_vectors * 16],
+        );
+        let data =
+            transmute_u8_to_slice::<f32>(&self.buffer[num_vectors * 16 + num_vectors * 16..]);
+        WalEntryDecoded {
+            doc_ids,
+            user_ids,
+            data,
+        }
+    }
 }

--- a/rs/index/src/wal/wal.rs
+++ b/rs/index/src/wal/wal.rs
@@ -63,7 +63,10 @@ impl Wal {
             let wal = WalFile::create(&file_path, seq_no)?;
             self.files.push(wal);
         }
-        self.files.last_mut().unwrap().append(doc_ids, user_ids, data)
+        self.files
+            .last_mut()
+            .unwrap()
+            .append(doc_ids, user_ids, data)
     }
 
     /// Append a new entry to the wal. If the last file is full, create a new file.
@@ -139,7 +142,9 @@ mod tests {
         let mut wal = Wal::open(dir.to_str().unwrap(), 1024).unwrap();
         for i in 0..5 {
             let data = vec![i as f32; 10];
-            let seq_no = wal.append(&vec![i as u128], &vec![i as u128], &data).unwrap();
+            let seq_no = wal
+                .append(&vec![i as u128], &vec![i as u128], &data)
+                .unwrap();
             assert_eq!(seq_no, i as u64);
         }
         assert_eq!(wal.files.len(), 1);

--- a/rs/index/src/wal/wal.rs
+++ b/rs/index/src/wal/wal.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use log::info;
 
 use super::file::WalFileIterator;
 use crate::wal::file::WalFile;
@@ -7,10 +8,18 @@ use crate::wal::file::WalFile;
 pub struct Wal {
     directory: String,
     files: Vec<WalFile>,
+
+    // The size of the wal file.
+    max_file_size: u64,
 }
 
 impl Wal {
-    pub fn open(directory: &str) -> Result<Self> {
+    pub fn open(directory: &str, max_file_size: u64) -> Result<Self> {
+        if !std::path::Path::new(directory).exists() {
+            info!("Wal directory {} does not exist, creating it", directory);
+            std::fs::create_dir_all(directory)?;
+        }
+
         let mut files = Vec::new();
 
         // Get all files in the directory. Each file will have the name of wal.<file_id>
@@ -20,6 +29,8 @@ impl Wal {
         file_paths.sort();
 
         if file_paths.is_empty() {
+            info!("No wal files found, creating a new one");
+
             // Create a new wal file
             let file_path = format!("{}/wal.0", directory);
             let wal = WalFile::create(&file_path, 0)?;
@@ -33,6 +44,7 @@ impl Wal {
         Ok(Self {
             directory: directory.to_string(),
             files,
+            max_file_size,
         })
     }
 
@@ -41,6 +53,29 @@ impl Wal {
             .iter()
             .map(|file| file.get_iterator().unwrap())
             .collect()
+    }
+
+    pub fn append(&mut self, doc_ids: &[u128], user_ids: &[u128], data: &[f32]) -> Result<u64> {
+        let last_file = self.files.last().unwrap();
+        if last_file.get_file_size()? >= self.max_file_size {
+            let seq_no = last_file.get_start_seq_no() + last_file.get_num_entries() as u64;
+            let file_path = format!("{}/wal.{}", self.directory, self.files.len());
+            let wal = WalFile::create(&file_path, seq_no)?;
+            self.files.push(wal);
+        }
+        self.files.last_mut().unwrap().append(doc_ids, user_ids, data)
+    }
+
+    /// Append a new entry to the wal. If the last file is full, create a new file.
+    pub fn append_raw(&mut self, data: &[u8]) -> Result<u64> {
+        let last_file = self.files.last().unwrap();
+        if last_file.get_file_size()? >= self.max_file_size {
+            let seq_no = last_file.get_start_seq_no() + last_file.get_num_entries() as u64;
+            let file_path = format!("{}/wal.{}", self.directory, self.files.len());
+            let wal = WalFile::create(&file_path, seq_no)?;
+            self.files.push(wal);
+        }
+        self.files.last_mut().unwrap().append_raw(data)
     }
 }
 
@@ -57,11 +92,11 @@ mod tests {
             let file_path = dir.join(format!("wal.{}", i));
             let mut wal = WalFile::create(&file_path.to_str().unwrap(), i * 10).unwrap();
             for j in 0..10 {
-                wal.append(&format!("hello_{}", j).as_bytes()).unwrap();
+                wal.append_raw(&format!("hello_{}", j).as_bytes()).unwrap();
             }
         }
 
-        let wal = Wal::open(dir.to_str().unwrap()).unwrap();
+        let wal = Wal::open(dir.to_str().unwrap(), 1024).unwrap();
         let iterators = wal.get_iterators();
         for (i, iterator) in iterators.iter().enumerate() {
             assert_eq!(iterator.last_seq_no(), (i as u64 + 1) * 10 - 1);
@@ -72,8 +107,52 @@ mod tests {
     fn test_wal_open_empty_dir() {
         let tmp_dir = tempdir::TempDir::new("wal_test").unwrap();
         let dir = tmp_dir.path();
-        let wal = Wal::open(dir.to_str().unwrap()).unwrap();
+        let wal = Wal::open(dir.to_str().unwrap(), 1024).unwrap();
         assert_eq!(wal.files.len(), 1);
         assert_eq!(wal.files[0].get_num_entries(), 0);
+    }
+
+    #[test]
+    fn test_wal_append_raw() {
+        let tmp_dir = tempdir::TempDir::new("wal_test").unwrap();
+        let dir = tmp_dir.path();
+        let mut wal = Wal::open(dir.to_str().unwrap(), 1024).unwrap();
+        for i in 0..100 {
+            let seq_no = wal.append_raw(&format!("hello{}", i).as_bytes()).unwrap();
+            assert_eq!(seq_no, i as u64);
+        }
+        assert_eq!(wal.files.len(), 2);
+
+        let mut iterators = wal.get_iterators();
+        let mut last_it = iterators.pop().unwrap();
+        for i in 93..100 {
+            let entry = last_it.next().unwrap().unwrap();
+            assert_eq!(entry.seq_no, i as u64);
+            assert_eq!(entry.buffer, format!("hello{}", i).as_bytes());
+        }
+    }
+
+    #[test]
+    fn test_wal_append() {
+        let tmp_dir = tempdir::TempDir::new("wal_test").unwrap();
+        let dir = tmp_dir.path();
+        let mut wal = Wal::open(dir.to_str().unwrap(), 1024).unwrap();
+        for i in 0..5 {
+            let data = vec![i as f32; 10];
+            let seq_no = wal.append(&vec![i as u128], &vec![i as u128], &data).unwrap();
+            assert_eq!(seq_no, i as u64);
+        }
+        assert_eq!(wal.files.len(), 1);
+
+        let mut iterators = wal.get_iterators();
+        let mut last_it = iterators.pop().unwrap();
+        for i in 0..5 {
+            let entry = last_it.next().unwrap().unwrap();
+            assert_eq!(entry.seq_no, i as u64);
+            let decoded = entry.decode(10);
+            assert_eq!(decoded.doc_ids, vec![i as u128]);
+            assert_eq!(decoded.user_ids, vec![i as u128]);
+            assert_eq!(decoded.data, vec![i as f32; 10]);
+        }
     }
 }

--- a/rs/proto/proto/muopdb.proto
+++ b/rs/proto/proto/muopdb.proto
@@ -96,6 +96,7 @@ message CreateCollectionRequest {
   optional uint64 max_posting_list_size = 22;
   optional float posting_list_kmeans_unbalanced_penalty = 23;
   optional bool reindex = 24;
+  optional uint64 wal_file_size = 25;
 }
 
 message CreateCollectionResponse {

--- a/rs/proto/src/muopdb.rs
+++ b/rs/proto/src/muopdb.rs
@@ -103,6 +103,8 @@ pub struct CreateCollectionRequest {
     pub posting_list_kmeans_unbalanced_penalty: ::core::option::Option<f32>,
     #[prost(bool, optional, tag = "24")]
     pub reindex: ::core::option::Option<bool>,
+    #[prost(uint64, optional, tag = "25")]
+    pub wal_file_size: ::core::option::Option<u64>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]


### PR DESCRIPTION
Hook WAL into insertion, and default to not using WAL. This option must be selected on collection creation.