### PR TITLE
Move Quantizer template to Collection

### DIFF
--- a/rs/index/src/collection/collection.rs
+++ b/rs/index/src/collection/collection.rs
@@ -1,0 +1,1140 @@
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use anyhow::{Ok, Result};
+use atomic_refcell::AtomicRefCell;
+use config::collection::CollectionConfig;
+use dashmap::DashMap;
+use fs_extra::dir::CopyOptions;
+use lock_api::RwLockUpgradableReadGuard;
+use log::{debug, info};
+use parking_lot::{RawRwLock, RwLock};
+use quantization::quantization::Quantizer;
+use tokio::sync::mpsc::{self, Receiver, Sender};
+
+use super::snapshot::Snapshot;
+use super::{OpChannelEntry, TableOfContent, VersionsInfo};
+use crate::multi_spann::reader::MultiSpannReader;
+use crate::optimizers::SegmentOptimizer;
+use crate::segment::immutable_segment::ImmutableSegment;
+use crate::segment::mutable_segment::MutableSegment;
+use crate::segment::pending_segment::PendingSegment;
+use crate::segment::{BoxedImmutableSegment, Segment};
+use crate::wal::entry::WalOpType;
+use crate::wal::wal::Wal;
+
+/// Collection is thread-safe. All pub fn are thread-safe.
+pub struct Collection<Q: Quantizer + Clone> {
+    pub versions: DashMap<u64, TableOfContent>,
+    all_segments: DashMap<String, BoxedImmutableSegment<Q>>,
+    versions_info: RwLock<VersionsInfo>,
+    base_directory: String,
+    mutable_segment: RwLock<MutableSegment>,
+    segment_config: CollectionConfig,
+    wal: Option<RwLock<Wal>>,
+
+    // A channel for sending ops to collection
+    sender: Sender<OpChannelEntry>,
+    receiver: AtomicRefCell<Receiver<OpChannelEntry>>,
+
+    last_flush_time: Mutex<Instant>,
+
+    // A mutex for flushing
+    flushing: Mutex<()>,
+}
+
+impl<Q: Quantizer + Clone> Collection<Q> {
+    pub fn new(base_directory: String, segment_config: CollectionConfig) -> Result<Self> {
+        let versions: DashMap<u64, TableOfContent> = DashMap::new();
+        versions.insert(0, TableOfContent::new(vec![]));
+
+        // Create a new segment_config with a random name
+        let random_name = format!("tmp_segment_{}", rand::random::<u64>());
+        let segment_base_directory = format!("{}/{}", base_directory, random_name);
+
+        let mutable_segment = RwLock::new(MutableSegment::new(
+            segment_config.clone(),
+            segment_base_directory,
+        )?);
+
+        let wal = if segment_config.wal_file_size > 0 {
+            let wal_directory = format!("{}/wal", base_directory);
+            Some(RwLock::new(Wal::open(
+                &wal_directory,
+                segment_config.wal_file_size,
+                -1,
+            )?))
+        } else {
+            None
+        };
+
+        let (sender, receiver) = mpsc::channel(100);
+        let receiver = AtomicRefCell::new(receiver);
+        Ok(Self {
+            versions,
+            all_segments: DashMap::new(),
+            versions_info: RwLock::new(VersionsInfo::new()),
+            base_directory,
+            mutable_segment,
+            segment_config,
+            flushing: Mutex::new(()),
+            wal,
+            sender,
+            receiver,
+            last_flush_time: Mutex::new(Instant::now()),
+        })
+    }
+
+    pub fn init_new_collection(base_directory: String, config: &CollectionConfig) -> Result<()> {
+        std::fs::create_dir_all(base_directory.clone())?;
+
+        // Write version 0
+        let toc_path = format!("{}/version_0", base_directory);
+        let toc = TableOfContent::default();
+        serde_json::to_writer_pretty(std::fs::File::create(toc_path)?, &toc)?;
+
+        // Write the config file
+        let config_path = format!("{}/collection_config.json", base_directory);
+        serde_json::to_writer_pretty(std::fs::File::create(config_path)?, config)?;
+
+        Ok(())
+    }
+
+    pub fn init_from(
+        base_directory: String,
+        version: u64,
+        toc: TableOfContent,
+        segments: Vec<BoxedImmutableSegment<Q>>,
+        segment_config: CollectionConfig,
+    ) -> Result<Self> {
+        let versions_info = RwLock::new(VersionsInfo::new());
+        versions_info.write().current_version = version;
+        versions_info.write().version_ref_counts.insert(version, 0);
+
+        let all_segments = DashMap::new();
+        toc.toc
+            .iter()
+            .zip(segments.into_iter())
+            .for_each(|(name, segment)| {
+                all_segments.insert(name.clone(), segment);
+            });
+        let last_sequence_number = toc.sequence_number;
+
+        let versions = DashMap::new();
+        versions.insert(version, toc);
+
+        // Remove all directories whose name starts with tmp_segment_
+        let base_dir = std::path::Path::new(&base_directory);
+        if base_dir.exists() {
+            for entry in std::fs::read_dir(base_dir)? {
+                let entry = entry?;
+                let path = entry.path();
+                if path.is_dir() {
+                    if let Some(file_name) = path.file_name() {
+                        if let Some(file_name_str) = file_name.to_str() {
+                            if file_name_str.starts_with("tmp_segment_") {
+                                std::fs::remove_dir_all(path)?;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Create a new segment_config with a random name
+        let random_name = format!("tmp_segment_{}", rand::random::<u64>());
+        let random_base_directory = format!("{}/{}", base_directory, random_name);
+        std::fs::create_dir_all(&random_base_directory)?;
+        let mutable_segment = RwLock::new(MutableSegment::new(
+            segment_config.clone(),
+            random_base_directory,
+        )?);
+
+        let wal = if segment_config.wal_file_size > 0 {
+            let wal_directory = format!("{}/wal", base_directory);
+            let wal = Wal::open(
+                &wal_directory,
+                segment_config.wal_file_size,
+                last_sequence_number as i64,
+            )?;
+            let iterators = wal.get_iterators();
+            let mut seq_no = (last_sequence_number + 1) as i64;
+            for mut iterator in iterators {
+                if iterator.last_seq_no() < seq_no {
+                    debug!(
+                        "Skipping iterator with last seq_no: {}",
+                        iterator.last_seq_no()
+                    );
+                    continue;
+                }
+
+                iterator.skip_to(seq_no)?;
+                for op in iterator {
+                    if let anyhow::Result::Ok(wal_entry) = op {
+                        let entry_seq_no = wal_entry.seq_no;
+                        debug!("Processing op with seq_no: {}", entry_seq_no);
+                        let wal_entry = wal_entry.decode(segment_config.num_features);
+                        match wal_entry.op_type {
+                            WalOpType::Insert => {
+                                let doc_ids = wal_entry.doc_ids;
+                                let user_ids = wal_entry.user_ids;
+                                let data = wal_entry.data;
+
+                                data.chunks(segment_config.num_features)
+                                    .zip(doc_ids)
+                                    .for_each(|(vector, doc_id)| {
+                                        for user_id in user_ids {
+                                            mutable_segment
+                                                .write()
+                                                .insert_for_user(
+                                                    *user_id,
+                                                    *doc_id,
+                                                    vector,
+                                                    entry_seq_no,
+                                                )
+                                                .unwrap();
+                                        }
+                                    });
+                            }
+                            WalOpType::Delete => {
+                                // TODO(hicder): Implement delete
+                            }
+                        }
+                    } else {
+                        break;
+                    }
+                    seq_no += 1;
+                }
+            }
+
+            Some(RwLock::new(wal))
+        } else {
+            None
+        };
+
+        let (sender, receiver) = mpsc::channel(100);
+        let receiver = AtomicRefCell::new(receiver);
+
+        Ok(Self {
+            versions,
+            all_segments,
+            versions_info,
+            base_directory,
+            mutable_segment,
+            segment_config,
+            flushing: Mutex::new(()),
+            wal,
+            sender,
+            receiver,
+            last_flush_time: Mutex::new(Instant::now()),
+        })
+    }
+
+    pub fn use_wal(&self) -> bool {
+        self.wal.is_some()
+    }
+
+    pub fn should_auto_flush(&self) -> bool {
+        if self.segment_config.max_pending_ops == 0 && self.segment_config.max_time_to_flush_ms == 0
+        {
+            return false;
+        }
+
+        if self.segment_config.max_pending_ops > 0 {
+            let current_seq_no = self.mutable_segment.read().last_sequence_number();
+            let flushed_seq_no = self
+                .versions
+                .get(&self.current_version())
+                .unwrap()
+                .sequence_number;
+            if current_seq_no as i64 - flushed_seq_no >= self.segment_config.max_pending_ops as i64
+            {
+                debug!(
+                    "Flushing because of max pending ops: {}",
+                    current_seq_no as i64 - flushed_seq_no as i64
+                );
+                return true;
+            }
+        }
+
+        if self.segment_config.max_time_to_flush_ms > 0 {
+            let last_flush_time = self.last_flush_time.lock().unwrap().clone();
+            let current_time = std::time::Instant::now();
+            if current_time.duration_since(last_flush_time)
+                >= std::time::Duration::from_millis(self.segment_config.max_time_to_flush_ms)
+            {
+                debug!(
+                    "Flushing because of max time to flush: {:?}",
+                    current_time.duration_since(last_flush_time)
+                );
+                return true;
+            }
+        }
+
+        false
+    }
+
+    pub async fn write_to_wal(
+        &self,
+        doc_ids: &[u128],
+        user_ids: &[u128],
+        data: &[f32],
+    ) -> Result<u64> {
+        if let Some(wal) = &self.wal {
+            // Write to WAL, and persist to disk
+            let seq_no = wal
+                .write()
+                .append(doc_ids, user_ids, data, WalOpType::Insert)?;
+
+            // Once the WAL is written, send the op to the channel
+            let op_channel_entry =
+                OpChannelEntry::new(doc_ids, user_ids, data, seq_no, WalOpType::Insert);
+            self.sender.send(op_channel_entry).await?;
+            Ok(seq_no)
+        } else {
+            Err(anyhow::anyhow!("WAL is not enabled"))
+        }
+    }
+
+    pub async fn process_one_op(&self) -> Result<usize> {
+        if let std::result::Result::Ok(op) = self.receiver.borrow_mut().try_recv() {
+            match op.op_type {
+                WalOpType::Insert => {
+                    info!("Processing insert operation with seq_no {}", op.seq_no);
+                    let doc_ids = op.doc_ids();
+                    let user_ids = op.user_ids();
+                    let data = op.data();
+                    data.chunks(self.segment_config.num_features)
+                        .zip(doc_ids)
+                        .for_each(|(vector, doc_id)| {
+                            self.insert_for_users(user_ids, *doc_id, vector, op.seq_no)
+                                .unwrap();
+                        });
+                }
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "Unsupported operation type: {:?}",
+                        op.op_type
+                    ))
+                }
+            }
+            Ok(1)
+        } else {
+            Ok(0)
+        }
+    }
+
+    pub fn insert(&self, doc_id: u128, data: &[f32]) -> Result<()> {
+        self.mutable_segment.write().insert(doc_id, data)
+    }
+
+    pub fn insert_for_users(
+        &self,
+        user_ids: &[u128],
+        doc_id: u128,
+        data: &[f32],
+        sequence_number: u64,
+    ) -> Result<()> {
+        for user_id in user_ids {
+            self.mutable_segment.write().insert_for_user(
+                *user_id,
+                doc_id,
+                data,
+                sequence_number,
+            )?;
+        }
+        Ok(())
+    }
+
+    pub fn dimensions(&self) -> usize {
+        self.segment_config.num_features
+    }
+
+    /// Turns mutable segment into immutable one, which is the only queryable segment type
+    /// currently.
+    pub fn flush(&self) -> Result<String> {
+        // Try to acquire the flushing lock. If it fails, then another thread is already flushing.
+        // This is a best effort approach, and we don't want to block the main thread.
+        match self.flushing.try_lock() {
+            std::result::Result::Ok(_) => {
+                // If there are no documents to flush, just return an empty string (meaning we're not flushing)
+                if self.mutable_segment.read().num_docs() == 0 {
+                    *self.last_flush_time.lock().unwrap() = Instant::now();
+                    return Ok(String::new());
+                }
+
+                let tmp_name = format!("tmp_segment_{}", rand::random::<u64>());
+                let writable_base_directory = format!("{}/{}", self.base_directory, tmp_name);
+                let mut new_writable_segment =
+                    MutableSegment::new(self.segment_config.clone(), writable_base_directory)?;
+
+                {
+                    // Grab the write lock and swap tmp_segment with mutable_segment
+                    let mut mutable_segment = self.mutable_segment.write();
+                    std::mem::swap(&mut *mutable_segment, &mut new_writable_segment);
+                }
+
+                let name_for_new_segment = format!("segment_{}", rand::random::<u64>());
+                let last_sequence_number = new_writable_segment.last_sequence_number();
+                new_writable_segment
+                    .build(self.base_directory.clone(), name_for_new_segment.clone())?;
+
+                // Read the segment
+                let spann_reader = MultiSpannReader::new(format!(
+                    "{}/{}",
+                    self.base_directory,
+                    name_for_new_segment.clone()
+                ));
+                let index = spann_reader.read::<Q>()?;
+                let segment = BoxedImmutableSegment::FinalizedSegment(Arc::new(RwLock::new(
+                    ImmutableSegment::new(index, name_for_new_segment.clone()),
+                )));
+                self.add_segments(
+                    vec![name_for_new_segment.clone()],
+                    vec![segment],
+                    last_sequence_number,
+                )?;
+                self.trim_wal(last_sequence_number as i64)?;
+                *self.last_flush_time.lock().unwrap() = Instant::now();
+                Ok(name_for_new_segment)
+            }
+            Err(_) => {
+                return Err(anyhow::anyhow!("Another thread is already flushing"));
+            }
+        }
+    }
+
+    /// Get a consistent snapshot for the collection
+    /// TODO(hicder): Get the consistent snapshot w.r.t. time.
+    pub fn get_snapshot(self: Arc<Self>) -> Result<Snapshot<Q>> {
+        if self.versions.is_empty() {
+            return Err(anyhow::anyhow!("Collection is empty"));
+        }
+
+        let current_version_number = self.get_current_version_and_increment();
+        let latest_version = self.versions.get(&current_version_number);
+        if latest_version.is_none() {
+            // It shouldn't happen, but just in case, we still release the version
+            self.release_version(current_version_number);
+            return Err(anyhow::anyhow!("Collection is empty"));
+        }
+
+        let toc = latest_version.unwrap().toc.clone();
+        let segments: Vec<BoxedImmutableSegment<Q>> = toc
+            .iter()
+            .map(|name| self.all_segments.get(name).unwrap().value().clone())
+            .collect();
+
+        Ok(Snapshot::new(
+            segments,
+            current_version_number,
+            Arc::clone(&self),
+        ))
+    }
+
+    pub fn get_current_toc(&self) -> TableOfContent {
+        self.versions
+            .get(&self.current_version())
+            .unwrap()
+            .value()
+            .clone()
+    }
+
+    /// Add segments to the collection, effectively creating a new version.
+    pub fn add_segments(
+        &self,
+        names: Vec<String>,
+        segments: Vec<BoxedImmutableSegment<Q>>,
+        last_sequence_number: u64,
+    ) -> Result<()> {
+        for (name, segment) in names.iter().zip(segments) {
+            self.all_segments.insert(name.clone(), segment);
+        }
+
+        // Under the upgradable read lock, we do the following:
+        // - Increment the current version
+        // - Add the new version to the toc, and persist to disk
+        // Under the write lock, we do the following:
+        // - Rename the tmp_version_{} to version_{}
+        // - Insert the new version to the toc
+        let versions_info_read = self.versions_info.upgradable_read();
+        let current_version = versions_info_read.current_version;
+        let new_version = current_version + 1;
+
+        let mut new_toc = self.versions.get(&current_version).unwrap().toc.clone();
+        new_toc.extend_from_slice(&names);
+        let new_pending = self.versions.get(&current_version).unwrap().pending.clone();
+
+        // Write the TOC to disk to a temporary file (with random name). Only rename atomically under the write lock.
+        let tmp_toc_path = format!(
+            "{}/tmp_version_{}",
+            self.base_directory,
+            rand::random::<u64>()
+        );
+        let mut tmp_toc_file = std::fs::File::create(tmp_toc_path.clone())?;
+        let toc = TableOfContent {
+            toc: new_toc,
+            pending: new_pending,
+            sequence_number: last_sequence_number as i64,
+        };
+        serde_json::to_writer_pretty(&mut tmp_toc_file, &toc)?;
+
+        // Once success, update the current version and ref counts.
+        let mut versions_info_write = RwLockUpgradableReadGuard::upgrade(versions_info_read);
+        let toc_path = format!("{}/version_{}", self.base_directory, new_version);
+        std::fs::rename(tmp_toc_path, toc_path)?;
+
+        versions_info_write.current_version = new_version;
+        versions_info_write
+            .version_ref_counts
+            .insert(new_version, 0);
+
+        self.versions.insert(new_version, toc);
+
+        Ok(())
+    }
+
+    /// Replace old segments with a new segment.
+    /// This function is not thread-safe. Caller needs to ensure the thread safety.
+    fn replace_segment(
+        &self,
+        new_segment: BoxedImmutableSegment<Q>,
+        old_segment_names: Vec<String>,
+        is_pending: bool,
+        versions_info_read: RwLockUpgradableReadGuard<RawRwLock, VersionsInfo>,
+    ) -> Result<()> {
+        self.all_segments
+            .insert(new_segment.name(), new_segment.clone());
+
+        // Under the lock, we do the following:
+        // - Increment the current version
+        // - Add the new version to the toc, and persist to disk
+        // - Insert the new version to the toc
+        let current_version = versions_info_read.current_version;
+        let new_version = current_version + 1;
+
+        let mut new_toc = self.versions.get(&current_version).unwrap().toc.clone();
+        new_toc.retain(|name| !old_segment_names.contains(name));
+        new_toc.push(new_segment.name());
+
+        let mut new_pending = self.versions.get(&current_version).unwrap().pending.clone();
+        let last_sequence_number = self.versions.get(&current_version).unwrap().sequence_number;
+        if is_pending {
+            new_pending.insert(new_segment.name(), old_segment_names);
+        } else {
+            // Cleanup the pending segment
+            new_pending.retain(|name, _| new_toc.contains(name));
+        }
+
+        // Write the TOC to disk to a temporary file. Only rename atomically under the write lock.
+        let tmp_toc_path = format!(
+            "{}/tmp_version_{}",
+            self.base_directory,
+            rand::random::<u64>()
+        );
+        let mut tmp_toc_file = std::fs::File::create(tmp_toc_path.clone())?;
+        let toc = TableOfContent {
+            toc: new_toc,
+            pending: new_pending,
+
+            // Since we're just replacing the segment, the sequence number should be the same.
+            sequence_number: last_sequence_number,
+        };
+        serde_json::to_writer_pretty(&mut tmp_toc_file, &toc)?;
+
+        let mut versions_info_write = RwLockUpgradableReadGuard::upgrade(versions_info_read);
+        let toc_path = format!("{}/version_{}", self.base_directory, new_version);
+        std::fs::rename(tmp_toc_path, toc_path)?;
+
+        versions_info_write.current_version = new_version;
+        versions_info_write
+            .version_ref_counts
+            .insert(new_version, 0);
+
+        self.versions.insert(new_version, toc);
+        Ok(())
+    }
+
+    /// Replace old segments with a new segment.
+    /// This function is thread-safe.
+    pub fn replace_segment_safe(
+        &self,
+        new_segment: BoxedImmutableSegment<Q>,
+        old_segment_names: Vec<String>,
+        is_pending: bool,
+    ) -> Result<()> {
+        let versions_info_read = self.versions_info.upgradable_read();
+        self.replace_segment(
+            new_segment,
+            old_segment_names,
+            is_pending,
+            versions_info_read,
+        )?;
+        Ok(())
+    }
+
+    pub fn current_version(&self) -> u64 {
+        self.versions_info.read().current_version
+    }
+
+    pub fn get_ref_count(&self, version_number: u64) -> usize {
+        self.versions_info
+            .read()
+            .version_ref_counts
+            .get(&version_number)
+            .unwrap_or(&0)
+            .clone()
+    }
+
+    /// Release the ref count for the version once the snapshot is no longer needed.
+    pub fn release_version(&self, version_number: u64) {
+        let mut versions_info_write = self.versions_info.write();
+        let count = *versions_info_write
+            .version_ref_counts
+            .get(&version_number)
+            .unwrap_or(&0);
+        versions_info_write
+            .version_ref_counts
+            .insert(version_number, count - 1);
+    }
+
+    /// This is thread-safe, and will increment the ref count for the version.
+    fn get_current_version_and_increment(&self) -> u64 {
+        let mut versions_info_write = self.versions_info.write();
+        let current_version = versions_info_write.current_version;
+
+        let count = *versions_info_write
+            .version_ref_counts
+            .get(&current_version)
+            .unwrap_or(&0);
+        versions_info_write
+            .version_ref_counts
+            .insert(current_version, count + 1);
+
+        current_version
+    }
+
+    pub fn get_all_segment_names(&self) -> Vec<String> {
+        self.all_segments
+            .iter()
+            .map(|pair| pair.key().clone())
+            .collect()
+    }
+
+    pub fn init_optimizing(&self, segments: &Vec<String>) -> Result<String> {
+        let random_name = format!("pending_segment_{}", rand::random::<u64>());
+        let pending_segment_path = format!("{}/{}", self.base_directory, random_name);
+        std::fs::create_dir_all(pending_segment_path.clone())?;
+        let mut current_segments = Vec::new();
+        for segment in segments {
+            current_segments.push(self.all_segments.get(segment).unwrap().clone());
+        }
+        let pending_segment =
+            PendingSegment::<Q>::new(current_segments.clone(), pending_segment_path);
+        let new_boxed_segment =
+            BoxedImmutableSegment::PendingSegment(Arc::new(RwLock::new(pending_segment)));
+        self.replace_segment_safe(new_boxed_segment, segments.clone(), true)?;
+
+        Ok(random_name)
+    }
+
+    fn pending_to_finalized(
+        &self,
+        pending_segment: &str,
+        versions_info_read: RwLockUpgradableReadGuard<RawRwLock, VersionsInfo>,
+    ) -> Result<()> {
+        let random_name = format!("segment_{}", rand::random::<u64>());
+
+        // Hardlink the pending segment to the new segment
+        let pending_segment_path = format!("{}/{}", self.base_directory, pending_segment);
+        let new_segment_path = format!("{}/{}", self.base_directory, random_name);
+
+        // Create and copy content of the pending segment to the new segment
+        std::fs::create_dir_all(new_segment_path.clone())?;
+
+        let mut options = CopyOptions::default();
+        options.content_only = true;
+        fs_extra::dir::copy(
+            pending_segment_path.clone(),
+            new_segment_path.clone(),
+            &options,
+        )?;
+
+        // Replace the pending segment with the new segment
+        let index = MultiSpannReader::new(new_segment_path.clone()).read::<Q>()?;
+        let new_segment = BoxedImmutableSegment::FinalizedSegment(Arc::new(RwLock::new(
+            ImmutableSegment::new(index, random_name.clone()),
+        )));
+        self.replace_segment(
+            new_segment,
+            vec![pending_segment.to_string()],
+            false,
+            versions_info_read,
+        )?;
+        Ok(())
+    }
+
+    pub fn run_optimizer(
+        &self,
+        optimizer: &impl SegmentOptimizer<Q>,
+        pending_segment: &str,
+    ) -> Result<()> {
+        let x = self.all_segments.get(pending_segment).unwrap();
+        let segment = x.value().clone();
+        match segment {
+            BoxedImmutableSegment::PendingSegment(pending_segment) => {
+                let mut pending_segment = pending_segment.upgradable_read();
+                optimizer.optimize(&pending_segment)?;
+                pending_segment.build_index()?;
+                pending_segment.try_with_upgraded(|pending_segment_write| {
+                    pending_segment_write.apply_pending_deletions()?;
+                    pending_segment_write.switch_to_internal_index();
+                    Ok(())
+                });
+            }
+            _ => {}
+        }
+
+        // Make the pending segment finalized
+        // Note that this function will upgrade toc lock.
+        let toc_locked = self.versions_info.upgradable_read();
+        self.pending_to_finalized(pending_segment, toc_locked)
+    }
+
+    fn trim_wal(&self, flushed_seq_no: i64) -> Result<()> {
+        if let Some(wal) = &self.wal {
+            wal.write().trim_wal(flushed_seq_no)?;
+        }
+        Ok(())
+    }
+}
+
+// Test
+#[cfg(test)]
+mod tests {
+
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
+    use anyhow::{Ok, Result};
+    use config::collection::CollectionConfig;
+    use parking_lot::RwLock;
+    use quantization::noq::noq::NoQuantizerL2;
+    use rand::Rng;
+    use tempdir::TempDir;
+
+    use crate::collection::collection::Collection;
+    use crate::collection::reader::CollectionReader;
+    use crate::optimizers::noop::NoopOptimizer;
+    use crate::segment::{BoxedImmutableSegment, MockedSegment, Segment};
+    use crate::utils::SearchContext;
+
+    #[test]
+    fn test_collection() -> Result<()> {
+        let temp_dir = TempDir::new("test_collection")?;
+        let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
+        let segment_config = CollectionConfig::default_test_config();
+        let collection = Arc::new(
+            Collection::<NoQuantizerL2>::new(base_directory.clone(), segment_config).unwrap(),
+        );
+
+        {
+            let segment1: BoxedImmutableSegment<NoQuantizerL2> =
+                BoxedImmutableSegment::MockedNoQuantizationSegment(Arc::new(RwLock::new(
+                    MockedSegment::new("segment1".to_string()),
+                )));
+            let segment2: BoxedImmutableSegment<NoQuantizerL2> =
+                BoxedImmutableSegment::MockedNoQuantizationSegment(Arc::new(RwLock::new(
+                    MockedSegment::new("segment2".to_string()),
+                )));
+
+            collection
+                .add_segments(
+                    vec!["segment1".to_string(), "segment2".to_string()],
+                    vec![segment1.clone(), segment2.clone()],
+                    0,
+                )
+                .unwrap();
+        }
+        let current_version = collection.current_version();
+        assert_eq!(current_version, 1);
+
+        let version_1 = 1;
+        {
+            let snapshot = collection.clone().get_snapshot()?;
+            assert_eq!(snapshot.segments.len(), 2);
+
+            let ref_count = collection.clone().get_ref_count(version_1);
+            assert_eq!(ref_count, 1);
+        }
+
+        // Snapshot should be dropped when it goes out of scope
+        let ref_count = collection.clone().get_ref_count(version_1);
+        assert_eq!(ref_count, 0);
+
+        // Create another snapshot, then add new segments
+        let version_2 = 2;
+        {
+            let snapshot = collection.clone().get_snapshot()?;
+            assert_eq!(snapshot.segments.len(), 2);
+            assert_eq!(snapshot.version(), 1);
+
+            collection
+                .add_segments(
+                    vec!["segment3".to_string(), "segment4".to_string()],
+                    vec![
+                        BoxedImmutableSegment::MockedNoQuantizationSegment(Arc::new(RwLock::new(
+                            MockedSegment::new("segment3".to_string()),
+                        ))),
+                        BoxedImmutableSegment::MockedNoQuantizationSegment(Arc::new(RwLock::new(
+                            MockedSegment::new("segment4".to_string()),
+                        ))),
+                    ],
+                    0,
+                )
+                .unwrap();
+
+            let ref_count = collection.clone().get_ref_count(version_1);
+            assert_eq!(ref_count, 1);
+
+            let ref_count = collection.clone().get_ref_count(version_2);
+            assert_eq!(ref_count, 0);
+        }
+
+        // Snapshot should be dropped when it goes out of scope
+        let ref_count = collection.clone().get_ref_count(version_1);
+        assert_eq!(ref_count, 0);
+        let ref_count = collection.clone().get_ref_count(version_2);
+        assert_eq!(ref_count, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_collection_multi_thread() -> Result<()> {
+        let temp_dir = TempDir::new("test_collection")?;
+        let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
+        let segment_config = CollectionConfig::default_test_config();
+
+        let collection = Arc::new(
+            Collection::<NoQuantizerL2>::new(base_directory.clone(), segment_config).unwrap(),
+        );
+        let stopped = Arc::new(AtomicBool::new(false));
+
+        // Create a thread to add segments, and let it runs for a while
+        let stopped_cpy = stopped.clone();
+        let collection_cpy = collection.clone();
+        std::thread::spawn(move || {
+            let segment1 = BoxedImmutableSegment::MockedNoQuantizationSegment(Arc::new(
+                RwLock::new(MockedSegment::new("segment1".to_string())),
+            ));
+            let segment2 = BoxedImmutableSegment::MockedNoQuantizationSegment(Arc::new(
+                RwLock::new(MockedSegment::new("segment2".to_string())),
+            ));
+
+            collection_cpy
+                .add_segments(
+                    vec!["segment1".to_string(), "segment2".to_string()],
+                    vec![segment1.clone(), segment2.clone()],
+                    0,
+                )
+                .unwrap();
+
+            while !stopped_cpy.load(std::sync::atomic::Ordering::Relaxed) {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+        });
+
+        // Sleep until there is a new version
+        let mut latest_version = collection.clone().current_version();
+        while latest_version != 1 {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            latest_version = collection.clone().current_version();
+        }
+
+        // Create another thread to get a snapshot
+        let collection_cpy = collection.clone();
+        let stopped_cpy = stopped.clone();
+        std::thread::spawn(move || {
+            let snapshot = collection_cpy.clone().get_snapshot().unwrap();
+            assert_eq!(snapshot.segments.len(), 2);
+            assert_eq!(snapshot.version(), 1);
+
+            let version_1 = 1;
+            let ref_count = collection_cpy.clone().get_ref_count(version_1);
+            assert_eq!(ref_count, 1);
+
+            while !stopped_cpy.load(std::sync::atomic::Ordering::Relaxed) {
+                assert_eq!(snapshot.version(), 1);
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+        });
+
+        // Sleep for 200ms, then check ref count
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        let version_1 = 1;
+        let ref_count = collection.clone().get_ref_count(version_1);
+        assert_eq!(ref_count, 1);
+
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        stopped.store(true, std::sync::atomic::Ordering::Relaxed);
+        Ok(())
+    }
+
+    #[test]
+    fn test_collection_optimizer() -> Result<()> {
+        let temp_dir = TempDir::new("test_collection")?;
+        let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
+        let segment_config = CollectionConfig::default_test_config();
+        let collection = Arc::new(
+            Collection::<NoQuantizerL2>::new(base_directory.clone(), segment_config).unwrap(),
+        );
+
+        // Add a document and flush
+        collection.insert_for_users(&[0], 1, &[1.0, 2.0, 3.0, 4.0], 0)?;
+        collection.flush()?;
+
+        let segment_names = collection.get_all_segment_names();
+        assert_eq!(segment_names.len(), 1);
+
+        let pending_segment = collection.init_optimizing(&segment_names)?;
+
+        let snapshot = collection.clone().get_snapshot()?;
+        assert_eq!(snapshot.segments.len(), 1);
+        assert_eq!(snapshot.version(), 2);
+        let segment_name = snapshot.segments[0].name();
+        assert_eq!(segment_name, pending_segment);
+
+        let mut context = SearchContext::new(false);
+        let result = snapshot
+            .search_for_ids(&[0], &[1.0, 2.0, 3.0, 4.0], 10, 10, &mut context)
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, 1);
+
+        let optimizer = NoopOptimizer::new();
+        collection.run_optimizer(&optimizer, &pending_segment)?;
+
+        let snapshot = collection.clone().get_snapshot()?;
+        assert_eq!(snapshot.segments.len(), 1);
+        assert_eq!(snapshot.version(), 3);
+
+        let toc = collection.get_current_toc();
+        assert_eq!(toc.toc.len(), 1);
+        assert_eq!(toc.pending.len(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_collection_multi_thread_optimizer() -> Result<()> {
+        let temp_dir = TempDir::new("test_collection")?;
+        let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
+        let segment_config = CollectionConfig::default_test_config();
+        let collection = Arc::new(
+            Collection::<NoQuantizerL2>::new(base_directory.clone(), segment_config).unwrap(),
+        );
+
+        collection.insert_for_users(&[0], 1, &[1.0, 2.0, 3.0, 4.0], 0)?;
+        collection.flush()?;
+
+        // A thread to optimize the segment
+        let collection_cpy_for_optimizer = collection.clone();
+        let collection_cpy_for_query = collection.clone();
+
+        let stopped = Arc::new(AtomicBool::new(false));
+        let stopped_cpy_for_optimizer = stopped.clone();
+        std::thread::spawn(move || {
+            while !stopped_cpy_for_optimizer.load(std::sync::atomic::Ordering::Relaxed) {
+                let c = collection_cpy_for_optimizer.clone();
+                let snapshot = c.get_snapshot().unwrap();
+                let segment_names = snapshot.segments.iter().map(|s| s.name()).collect();
+                let pending_segment = collection_cpy_for_optimizer
+                    .init_optimizing(&segment_names)
+                    .unwrap();
+
+                let toc = collection_cpy_for_optimizer.get_current_toc();
+                assert_eq!(toc.pending.len(), 1);
+
+                // Sleep randomly between 100ms and 200ms
+                let sleep_duration = rand::thread_rng().gen_range(100..200);
+                std::thread::sleep(std::time::Duration::from_millis(sleep_duration));
+
+                let optimizer = NoopOptimizer::new();
+                collection_cpy_for_optimizer
+                    .run_optimizer(&optimizer, &pending_segment)
+                    .unwrap();
+
+                let toc = collection_cpy_for_optimizer.get_current_toc();
+                assert_eq!(toc.pending.len(), 0);
+            }
+        });
+
+        // A thread to query the collection
+        let stopped_cpy_for_query = stopped.clone();
+        std::thread::spawn(move || {
+            while !stopped_cpy_for_query.load(std::sync::atomic::Ordering::Relaxed) {
+                let c = collection_cpy_for_query.clone();
+                let snapshot = c.get_snapshot().unwrap();
+                let mut context = SearchContext::new(false);
+                let result = snapshot
+                    .search_for_ids(&[0], &[1.0, 2.0, 3.0, 4.0], 10, 10, &mut context)
+                    .unwrap();
+                assert_eq!(result.len(), 1);
+                assert_eq!(result[0].id, 1);
+
+                // Sleep randomly between 100ms and 200ms
+                let sleep_duration = rand::thread_rng().gen_range(100..200);
+                std::thread::sleep(std::time::Duration::from_millis(sleep_duration));
+            }
+        });
+
+        // Sleep for 5 seconds, then stop the threads
+        std::thread::sleep(std::time::Duration::from_millis(5000));
+        stopped.store(true, std::sync::atomic::Ordering::Relaxed);
+        Ok(())
+    }
+
+    #[test]
+    fn test_collection_reader() -> Result<()> {
+        let temp_dir = TempDir::new("test_collection")?;
+        let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
+        let segment_config = CollectionConfig::default_test_config();
+        // write the collection config
+        let collection_config_path = format!("{}/collection_config.json", base_directory);
+        serde_json::to_writer_pretty(
+            std::fs::File::create(collection_config_path)?,
+            &segment_config,
+        )?;
+
+        {
+            let collection = Arc::new(
+                Collection::<NoQuantizerL2>::new(base_directory.clone(), segment_config).unwrap(),
+            );
+
+            collection.insert_for_users(&[0], 1, &[1.0, 2.0, 3.0, 4.0], 0)?;
+            collection.flush()?;
+
+            let segment_names = collection.get_all_segment_names();
+            assert_eq!(segment_names.len(), 1);
+
+            let pending_segment = collection.init_optimizing(&segment_names)?;
+
+            let toc = collection.get_current_toc();
+            assert_eq!(toc.pending.len(), 1);
+            assert_eq!(toc.pending.get(&pending_segment).unwrap().len(), 1);
+        }
+
+        let reader = CollectionReader::new(base_directory);
+        let collection = reader.read::<NoQuantizerL2>()?;
+        let toc = collection.get_current_toc();
+        assert_eq!(toc.pending.len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_collection_with_wal() -> Result<()> {
+        let temp_dir = TempDir::new("test_collection")?;
+        let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
+        let mut segment_config = CollectionConfig::default_test_config();
+        segment_config.wal_file_size = 1024 * 1024;
+
+        let collection = Arc::new(
+            Collection::<NoQuantizerL2>::new(base_directory.clone(), segment_config).unwrap(),
+        );
+        collection
+            .write_to_wal(&[1], &[0], &[1.0, 2.0, 3.0, 4.0])
+            .await?;
+        collection
+            .write_to_wal(&[2], &[0], &[1.0, 2.0, 3.0, 4.0])
+            .await?;
+        collection
+            .write_to_wal(&[3], &[0], &[1.0, 2.0, 3.0, 4.0])
+            .await?;
+        collection
+            .write_to_wal(&[4], &[0], &[1.0, 2.0, 3.0, 4.0])
+            .await?;
+        collection
+            .write_to_wal(&[5], &[0], &[1.0, 2.0, 3.0, 4.0])
+            .await?;
+
+        // Process all ops
+        loop {
+            let op = collection.process_one_op().await?;
+            if op == 0 {
+                break;
+            }
+        }
+        collection.flush()?;
+        let toc = collection.get_current_toc();
+        assert_eq!(toc.pending.len(), 0);
+        assert_eq!(toc.sequence_number, 4);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_collection_with_wal_reopen() -> Result<()> {
+        let temp_dir = TempDir::new("test_collection")?;
+        let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
+        let mut segment_config = CollectionConfig::default_test_config();
+        segment_config.wal_file_size = 1024 * 1024;
+
+        Collection::<NoQuantizerL2>::init_new_collection(base_directory.clone(), &segment_config)?;
+
+        // Insert but don't flush
+        {
+            let reader = CollectionReader::new(base_directory.clone());
+            let collection = reader.read::<NoQuantizerL2>()?;
+            collection
+                .write_to_wal(&[1], &[0], &[1.0, 2.0, 3.0, 4.0])
+                .await?;
+            collection
+                .write_to_wal(&[2], &[0], &[1.0, 2.0, 3.0, 4.0])
+                .await?;
+
+            // Process all ops
+            loop {
+                let op = collection.process_one_op().await?;
+                if op == 0 {
+                    break;
+                }
+            }
+        }
+
+        {
+            let reader = CollectionReader::new(base_directory.clone());
+            let collection = reader.read::<NoQuantizerL2>()?;
+            let toc = collection.get_current_toc();
+            assert_eq!(toc.pending.len(), 0);
+            assert_eq!(toc.sequence_number, -1);
+
+            collection.flush()?;
+            let toc = collection.get_current_toc();
+            assert_eq!(toc.pending.len(), 0);
+            assert_eq!(toc.sequence_number, 1);
+
+            // Write 2 more ops, but don't flush
+            collection
+                .write_to_wal(&[3], &[0], &[1.0, 2.0, 3.0, 4.0])
+                .await?;
+            collection
+                .write_to_wal(&[4], &[0], &[1.0, 2.0, 3.0, 4.0])
+                .await?;
+        }
+
+        {
+            let reader = CollectionReader::new(base_directory.clone());
+            let collection = reader.read::<NoQuantizerL2>()?;
+            let toc = collection.get_current_toc();
+            assert_eq!(toc.pending.len(), 0);
+            assert_eq!(toc.sequence_number, 1);
+
+            collection.flush()?;
+            let toc = collection.get_current_toc();
+            assert_eq!(toc.pending.len(), 0);
+            assert_eq!(toc.sequence_number, 3);
+        }
+
+        Ok(())
+    }
+}

--- a/rs/index/src/collection/mod.rs
+++ b/rs/index/src/collection/mod.rs
@@ -1,33 +1,22 @@
+pub mod collection;
 pub mod reader;
 pub mod snapshot;
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::sync::Arc;
 
-use anyhow::{Ok, Result};
-use atomic_refcell::AtomicRefCell;
-use config::collection::CollectionConfig;
-use dashmap::DashMap;
-use fs_extra::dir::CopyOptions;
-use lock_api::RwLockUpgradableReadGuard;
-use log::{debug, info};
-use parking_lot::{RawRwLock, RwLock};
-use quantization::quantization::Quantizer;
+use anyhow::Result;
+use collection::Collection;
+use quantization::noq::noq::NoQuantizer;
+use quantization::pq::pq::ProductQuantizer;
 use serde::{Deserialize, Serialize};
-use snapshot::Snapshot;
-use tokio::sync::mpsc::{self, Receiver, Sender};
+use snapshot::SnapshotWithQuantizer;
+use utils::distance::l2::L2DistanceCalculator;
 use utils::mem::{transmute_slice_to_u8, transmute_u8_to_slice};
 
 use crate::index::Searchable;
-use crate::multi_spann::reader::MultiSpannReader;
-use crate::optimizers::SegmentOptimizer;
-use crate::segment::immutable_segment::ImmutableSegment;
-use crate::segment::mutable_segment::MutableSegment;
-use crate::segment::pending_segment::PendingSegment;
-use crate::segment::{BoxedImmutableSegment, Segment};
+use crate::segment::Segment;
 use crate::wal::entry::WalOpType;
-use crate::wal::wal::Wal;
 
 pub trait SegmentSearchable: Searchable + Segment {}
 pub type BoxedSegmentSearchable = Box<dyn SegmentSearchable + Send + Sync>;
@@ -139,255 +128,25 @@ impl OpChannelEntry {
     }
 }
 
-/// Collection is thread-safe. All pub fn are thread-safe.
-pub struct Collection<Q: Quantizer + Clone> {
-    pub versions: DashMap<u64, TableOfContent>,
-    all_segments: DashMap<String, BoxedImmutableSegment<Q>>,
-    versions_info: RwLock<VersionsInfo>,
-    base_directory: String,
-    mutable_segment: RwLock<MutableSegment>,
-    segment_config: CollectionConfig,
-    wal: Option<RwLock<Wal>>,
-
-    // A channel for sending ops to collection
-    sender: Sender<OpChannelEntry>,
-    receiver: AtomicRefCell<Receiver<OpChannelEntry>>,
-
-    last_flush_time: Mutex<Instant>,
-
-    // A mutex for flushing
-    flushing: Mutex<()>,
+#[derive(Clone)]
+pub enum BoxedCollection {
+    CollectionNoQuantizationL2(Arc<Collection<NoQuantizer<L2DistanceCalculator>>>),
+    CollectionProductQuantization(Arc<Collection<ProductQuantizer<L2DistanceCalculator>>>),
 }
 
-impl<Q: Quantizer + Clone> Collection<Q> {
-    pub fn new(base_directory: String, segment_config: CollectionConfig) -> Result<Self> {
-        let versions: DashMap<u64, TableOfContent> = DashMap::new();
-        versions.insert(0, TableOfContent::new(vec![]));
-
-        // Create a new segment_config with a random name
-        let random_name = format!("tmp_segment_{}", rand::random::<u64>());
-        let segment_base_directory = format!("{}/{}", base_directory, random_name);
-
-        let mutable_segment = RwLock::new(MutableSegment::new(
-            segment_config.clone(),
-            segment_base_directory,
-        )?);
-
-        let wal = if segment_config.wal_file_size > 0 {
-            let wal_directory = format!("{}/wal", base_directory);
-            Some(RwLock::new(Wal::open(
-                &wal_directory,
-                segment_config.wal_file_size,
-                -1,
-            )?))
-        } else {
-            None
-        };
-
-        let (sender, receiver) = mpsc::channel(100);
-        let receiver = AtomicRefCell::new(receiver);
-        Ok(Self {
-            versions,
-            all_segments: DashMap::new(),
-            versions_info: RwLock::new(VersionsInfo::new()),
-            base_directory,
-            mutable_segment,
-            segment_config,
-            flushing: Mutex::new(()),
-            wal,
-            sender,
-            receiver,
-            last_flush_time: Mutex::new(Instant::now()),
-        })
-    }
-
-    pub fn init_new_collection(base_directory: String, config: &CollectionConfig) -> Result<()> {
-        std::fs::create_dir_all(base_directory.clone())?;
-
-        // Write version 0
-        let toc_path = format!("{}/version_0", base_directory);
-        let toc = TableOfContent::default();
-        serde_json::to_writer_pretty(std::fs::File::create(toc_path)?, &toc)?;
-
-        // Write the config file
-        let config_path = format!("{}/collection_config.json", base_directory);
-        serde_json::to_writer_pretty(std::fs::File::create(config_path)?, config)?;
-
-        Ok(())
-    }
-
-    pub fn init_from(
-        base_directory: String,
-        version: u64,
-        toc: TableOfContent,
-        segments: Vec<BoxedImmutableSegment<Q>>,
-        segment_config: CollectionConfig,
-    ) -> Result<Self> {
-        let versions_info = RwLock::new(VersionsInfo::new());
-        versions_info.write().current_version = version;
-        versions_info.write().version_ref_counts.insert(version, 0);
-
-        let all_segments = DashMap::new();
-        toc.toc
-            .iter()
-            .zip(segments.into_iter())
-            .for_each(|(name, segment)| {
-                all_segments.insert(name.clone(), segment);
-            });
-        let last_sequence_number = toc.sequence_number;
-
-        let versions = DashMap::new();
-        versions.insert(version, toc);
-
-        // Remove all directories whose name starts with tmp_segment_
-        let base_dir = std::path::Path::new(&base_directory);
-        if base_dir.exists() {
-            for entry in std::fs::read_dir(base_dir)? {
-                let entry = entry?;
-                let path = entry.path();
-                if path.is_dir() {
-                    if let Some(file_name) = path.file_name() {
-                        if let Some(file_name_str) = file_name.to_str() {
-                            if file_name_str.starts_with("tmp_segment_") {
-                                std::fs::remove_dir_all(path)?;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Create a new segment_config with a random name
-        let random_name = format!("tmp_segment_{}", rand::random::<u64>());
-        let random_base_directory = format!("{}/{}", base_directory, random_name);
-        std::fs::create_dir_all(&random_base_directory)?;
-        let mutable_segment = RwLock::new(MutableSegment::new(
-            segment_config.clone(),
-            random_base_directory,
-        )?);
-
-        let wal = if segment_config.wal_file_size > 0 {
-            let wal_directory = format!("{}/wal", base_directory);
-            let wal = Wal::open(
-                &wal_directory,
-                segment_config.wal_file_size,
-                last_sequence_number as i64,
-            )?;
-            let iterators = wal.get_iterators();
-            let mut seq_no = (last_sequence_number + 1) as i64;
-            for mut iterator in iterators {
-                if iterator.last_seq_no() < seq_no {
-                    debug!(
-                        "Skipping iterator with last seq_no: {}",
-                        iterator.last_seq_no()
-                    );
-                    continue;
-                }
-
-                iterator.skip_to(seq_no)?;
-                for op in iterator {
-                    if let anyhow::Result::Ok(wal_entry) = op {
-                        let entry_seq_no = wal_entry.seq_no;
-                        debug!("Processing op with seq_no: {}", entry_seq_no);
-                        let wal_entry = wal_entry.decode(segment_config.num_features);
-                        match wal_entry.op_type {
-                            WalOpType::Insert => {
-                                let doc_ids = wal_entry.doc_ids;
-                                let user_ids = wal_entry.user_ids;
-                                let data = wal_entry.data;
-
-                                data.chunks(segment_config.num_features)
-                                    .zip(doc_ids)
-                                    .for_each(|(vector, doc_id)| {
-                                        for user_id in user_ids {
-                                            mutable_segment
-                                                .write()
-                                                .insert_for_user(
-                                                    *user_id,
-                                                    *doc_id,
-                                                    vector,
-                                                    entry_seq_no,
-                                                )
-                                                .unwrap();
-                                        }
-                                    });
-                            }
-                            WalOpType::Delete => {
-                                // TODO(hicder): Implement delete
-                            }
-                        }
-                    } else {
-                        break;
-                    }
-                    seq_no += 1;
-                }
-            }
-
-            Some(RwLock::new(wal))
-        } else {
-            None
-        };
-
-        let (sender, receiver) = mpsc::channel(100);
-        let receiver = AtomicRefCell::new(receiver);
-
-        Ok(Self {
-            versions,
-            all_segments,
-            versions_info,
-            base_directory,
-            mutable_segment,
-            segment_config,
-            flushing: Mutex::new(()),
-            wal,
-            sender,
-            receiver,
-            last_flush_time: Mutex::new(Instant::now()),
-        })
-    }
-
+impl BoxedCollection {
     pub fn use_wal(&self) -> bool {
-        self.wal.is_some()
+        match self {
+            BoxedCollection::CollectionNoQuantizationL2(collection) => collection.use_wal(),
+            BoxedCollection::CollectionProductQuantization(collection) => collection.use_wal(),
+        }
     }
 
-    pub fn should_auto_flush(&self) -> bool {
-        if self.segment_config.max_pending_ops == 0 && self.segment_config.max_time_to_flush_ms == 0
-        {
-            return false;
+    pub fn dimensions(&self) -> usize {
+        match self {
+            BoxedCollection::CollectionNoQuantizationL2(collection) => collection.dimensions(),
+            BoxedCollection::CollectionProductQuantization(collection) => collection.dimensions(),
         }
-
-        if self.segment_config.max_pending_ops > 0 {
-            let current_seq_no = self.mutable_segment.read().last_sequence_number();
-            let flushed_seq_no = self
-                .versions
-                .get(&self.current_version())
-                .unwrap()
-                .sequence_number;
-            if current_seq_no as i64 - flushed_seq_no >= self.segment_config.max_pending_ops as i64
-            {
-                debug!(
-                    "Flushing because of max pending ops: {}",
-                    current_seq_no as i64 - flushed_seq_no as i64
-                );
-                return true;
-            }
-        }
-
-        if self.segment_config.max_time_to_flush_ms > 0 {
-            let last_flush_time = self.last_flush_time.lock().unwrap().clone();
-            let current_time = std::time::Instant::now();
-            if current_time.duration_since(last_flush_time)
-                >= std::time::Duration::from_millis(self.segment_config.max_time_to_flush_ms)
-            {
-                debug!(
-                    "Flushing because of max time to flush: {:?}",
-                    current_time.duration_since(last_flush_time)
-                );
-                return true;
-            }
-        }
-
-        false
     }
 
     pub async fn write_to_wal(
@@ -396,52 +155,25 @@ impl<Q: Quantizer + Clone> Collection<Q> {
         user_ids: &[u128],
         data: &[f32],
     ) -> Result<u64> {
-        if let Some(wal) = &self.wal {
-            // Write to WAL, and persist to disk
-            let seq_no = wal
-                .write()
-                .append(doc_ids, user_ids, data, WalOpType::Insert)?;
-
-            // Once the WAL is written, send the op to the channel
-            let op_channel_entry =
-                OpChannelEntry::new(doc_ids, user_ids, data, seq_no, WalOpType::Insert);
-            self.sender.send(op_channel_entry).await?;
-            Ok(seq_no)
-        } else {
-            Err(anyhow::anyhow!("WAL is not enabled"))
-        }
-    }
-
-    pub async fn process_one_op(&self) -> Result<usize> {
-        if let std::result::Result::Ok(op) = self.receiver.borrow_mut().try_recv() {
-            match op.op_type {
-                WalOpType::Insert => {
-                    info!("Processing insert operation with seq_no {}", op.seq_no);
-                    let doc_ids = op.doc_ids();
-                    let user_ids = op.user_ids();
-                    let data = op.data();
-                    data.chunks(self.segment_config.num_features)
-                        .zip(doc_ids)
-                        .for_each(|(vector, doc_id)| {
-                            self.insert_for_users(user_ids, *doc_id, vector, op.seq_no)
-                                .unwrap();
-                        });
-                }
-                _ => {
-                    return Err(anyhow::anyhow!(
-                        "Unsupported operation type: {:?}",
-                        op.op_type
-                    ))
-                }
+        match self {
+            BoxedCollection::CollectionNoQuantizationL2(collection) => {
+                collection.write_to_wal(doc_ids, user_ids, data).await
             }
-            Ok(1)
-        } else {
-            Ok(0)
+            BoxedCollection::CollectionProductQuantization(collection) => {
+                collection.write_to_wal(doc_ids, user_ids, data).await
+            }
         }
     }
 
-    pub fn insert(&self, doc_id: u128, data: &[f32]) -> Result<()> {
-        self.mutable_segment.write().insert(doc_id, data)
+    pub fn should_auto_flush(&self) -> bool {
+        match self {
+            BoxedCollection::CollectionNoQuantizationL2(collection) => {
+                collection.should_auto_flush()
+            }
+            BoxedCollection::CollectionProductQuantization(collection) => {
+                collection.should_auto_flush()
+            }
+        }
     }
 
     pub fn insert_for_users(
@@ -449,800 +181,51 @@ impl<Q: Quantizer + Clone> Collection<Q> {
         user_ids: &[u128],
         doc_id: u128,
         data: &[f32],
-        sequence_number: u64,
+        seq_no: u64,
     ) -> Result<()> {
-        for user_id in user_ids {
-            self.mutable_segment.write().insert_for_user(
-                *user_id,
-                doc_id,
-                data,
-                sequence_number,
-            )?;
+        match self {
+            BoxedCollection::CollectionNoQuantizationL2(collection) => {
+                collection.insert_for_users(user_ids, doc_id, data, seq_no)
+            }
+            BoxedCollection::CollectionProductQuantization(collection) => {
+                collection.insert_for_users(user_ids, doc_id, data, seq_no)
+            }
         }
-        Ok(())
     }
 
-    pub fn dimensions(&self) -> usize {
-        self.segment_config.num_features
-    }
-
-    /// Turns mutable segment into immutable one, which is the only queryable segment type
-    /// currently.
     pub fn flush(&self) -> Result<String> {
-        // Try to acquire the flushing lock. If it fails, then another thread is already flushing.
-        // This is a best effort approach, and we don't want to block the main thread.
-        match self.flushing.try_lock() {
-            std::result::Result::Ok(_) => {
-                // If there are no documents to flush, just return an empty string (meaning we're not flushing)
-                if self.mutable_segment.read().num_docs() == 0 {
-                    *self.last_flush_time.lock().unwrap() = Instant::now();
-                    return Ok(String::new());
-                }
-
-                let tmp_name = format!("tmp_segment_{}", rand::random::<u64>());
-                let writable_base_directory = format!("{}/{}", self.base_directory, tmp_name);
-                let mut new_writable_segment =
-                    MutableSegment::new(self.segment_config.clone(), writable_base_directory)?;
-
-                {
-                    // Grab the write lock and swap tmp_segment with mutable_segment
-                    let mut mutable_segment = self.mutable_segment.write();
-                    std::mem::swap(&mut *mutable_segment, &mut new_writable_segment);
-                }
-
-                let name_for_new_segment = format!("segment_{}", rand::random::<u64>());
-                let last_sequence_number = new_writable_segment.last_sequence_number();
-                new_writable_segment
-                    .build(self.base_directory.clone(), name_for_new_segment.clone())?;
-
-                // Read the segment
-                let spann_reader = MultiSpannReader::new(format!(
-                    "{}/{}",
-                    self.base_directory,
-                    name_for_new_segment.clone()
-                ));
-                let index = spann_reader.read::<Q>()?;
-                let segment = BoxedImmutableSegment::FinalizedSegment(Arc::new(RwLock::new(
-                    ImmutableSegment::new(index, name_for_new_segment.clone()),
-                )));
-                self.add_segments(
-                    vec![name_for_new_segment.clone()],
-                    vec![segment],
-                    last_sequence_number,
-                )?;
-                self.trim_wal(last_sequence_number as i64)?;
-                *self.last_flush_time.lock().unwrap() = Instant::now();
-                Ok(name_for_new_segment)
-            }
-            Err(_) => {
-                return Err(anyhow::anyhow!("Another thread is already flushing"));
-            }
+        match self {
+            BoxedCollection::CollectionNoQuantizationL2(collection) => collection.flush(),
+            BoxedCollection::CollectionProductQuantization(collection) => collection.flush(),
         }
-    }
-
-    /// Get a consistent snapshot for the collection
-    /// TODO(hicder): Get the consistent snapshot w.r.t. time.
-    pub fn get_snapshot(self: Arc<Self>) -> Result<Snapshot<Q>> {
-        if self.versions.is_empty() {
-            return Err(anyhow::anyhow!("Collection is empty"));
-        }
-
-        let current_version_number = self.get_current_version_and_increment();
-        let latest_version = self.versions.get(&current_version_number);
-        if latest_version.is_none() {
-            // It shouldn't happen, but just in case, we still release the version
-            self.release_version(current_version_number);
-            return Err(anyhow::anyhow!("Collection is empty"));
-        }
-
-        let toc = latest_version.unwrap().toc.clone();
-        let segments: Vec<BoxedImmutableSegment<Q>> = toc
-            .iter()
-            .map(|name| self.all_segments.get(name).unwrap().value().clone())
-            .collect();
-        Ok(Snapshot::new(
-            segments,
-            current_version_number,
-            Arc::clone(&self),
-        ))
-    }
-
-    pub fn get_current_toc(&self) -> TableOfContent {
-        self.versions
-            .get(&self.current_version())
-            .unwrap()
-            .value()
-            .clone()
-    }
-
-    /// Add segments to the collection, effectively creating a new version.
-    pub fn add_segments(
-        &self,
-        names: Vec<String>,
-        segments: Vec<BoxedImmutableSegment<Q>>,
-        last_sequence_number: u64,
-    ) -> Result<()> {
-        for (name, segment) in names.iter().zip(segments) {
-            self.all_segments.insert(name.clone(), segment);
-        }
-
-        // Under the upgradable read lock, we do the following:
-        // - Increment the current version
-        // - Add the new version to the toc, and persist to disk
-        // Under the write lock, we do the following:
-        // - Rename the tmp_version_{} to version_{}
-        // - Insert the new version to the toc
-        let versions_info_read = self.versions_info.upgradable_read();
-        let current_version = versions_info_read.current_version;
-        let new_version = current_version + 1;
-
-        let mut new_toc = self.versions.get(&current_version).unwrap().toc.clone();
-        new_toc.extend_from_slice(&names);
-        let new_pending = self.versions.get(&current_version).unwrap().pending.clone();
-
-        // Write the TOC to disk to a temporary file (with random name). Only rename atomically under the write lock.
-        let tmp_toc_path = format!(
-            "{}/tmp_version_{}",
-            self.base_directory,
-            rand::random::<u64>()
-        );
-        let mut tmp_toc_file = std::fs::File::create(tmp_toc_path.clone())?;
-        let toc = TableOfContent {
-            toc: new_toc,
-            pending: new_pending,
-            sequence_number: last_sequence_number as i64,
-        };
-        serde_json::to_writer_pretty(&mut tmp_toc_file, &toc)?;
-
-        // Once success, update the current version and ref counts.
-        let mut versions_info_write = RwLockUpgradableReadGuard::upgrade(versions_info_read);
-        let toc_path = format!("{}/version_{}", self.base_directory, new_version);
-        std::fs::rename(tmp_toc_path, toc_path)?;
-
-        versions_info_write.current_version = new_version;
-        versions_info_write
-            .version_ref_counts
-            .insert(new_version, 0);
-
-        self.versions.insert(new_version, toc);
-
-        Ok(())
-    }
-
-    /// Replace old segments with a new segment.
-    /// This function is not thread-safe. Caller needs to ensure the thread safety.
-    fn replace_segment(
-        &self,
-        new_segment: BoxedImmutableSegment<Q>,
-        old_segment_names: Vec<String>,
-        is_pending: bool,
-        versions_info_read: RwLockUpgradableReadGuard<RawRwLock, VersionsInfo>,
-    ) -> Result<()> {
-        self.all_segments.insert(new_segment.name(), new_segment);
-
-        // Under the lock, we do the following:
-        // - Increment the current version
-        // - Add the new version to the toc, and persist to disk
-        // - Insert the new version to the toc
-        let current_version = versions_info_read.current_version;
-        let new_version = current_version + 1;
-
-        let mut new_toc = self.versions.get(&current_version).unwrap().toc.clone();
-        new_toc.retain(|name| !old_segment_names.contains(name));
-        new_toc.push(new_segment.name());
-
-        let mut new_pending = self.versions.get(&current_version).unwrap().pending.clone();
-        let last_sequence_number = self.versions.get(&current_version).unwrap().sequence_number;
-        if is_pending {
-            new_pending.insert(new_segment.name(), old_segment_names);
-        } else {
-            // Cleanup the pending segment
-            new_pending.retain(|name, _| new_toc.contains(name));
-        }
-
-        // Write the TOC to disk to a temporary file. Only rename atomically under the write lock.
-        let tmp_toc_path = format!(
-            "{}/tmp_version_{}",
-            self.base_directory,
-            rand::random::<u64>()
-        );
-        let mut tmp_toc_file = std::fs::File::create(tmp_toc_path.clone())?;
-        let toc = TableOfContent {
-            toc: new_toc,
-            pending: new_pending,
-
-            // Since we're just replacing the segment, the sequence number should be the same.
-            sequence_number: last_sequence_number,
-        };
-        serde_json::to_writer_pretty(&mut tmp_toc_file, &toc)?;
-
-        let mut versions_info_write = RwLockUpgradableReadGuard::upgrade(versions_info_read);
-        let toc_path = format!("{}/version_{}", self.base_directory, new_version);
-        std::fs::rename(tmp_toc_path, toc_path)?;
-
-        versions_info_write.current_version = new_version;
-        versions_info_write
-            .version_ref_counts
-            .insert(new_version, 0);
-
-        self.versions.insert(new_version, toc);
-        Ok(())
-    }
-
-    /// Replace old segments with a new segment.
-    /// This function is thread-safe.
-    pub fn replace_segment_safe(
-        &self,
-        new_segment: BoxedImmutableSegment<Q>,
-        old_segment_names: Vec<String>,
-        is_pending: bool,
-    ) -> Result<()> {
-        let versions_info_read = self.versions_info.upgradable_read();
-        self.replace_segment(
-            new_segment,
-            old_segment_names,
-            is_pending,
-            versions_info_read,
-        )?;
-        Ok(())
-    }
-
-    pub fn current_version(&self) -> u64 {
-        self.versions_info.read().current_version
-    }
-
-    pub fn get_ref_count(&self, version_number: u64) -> usize {
-        self.versions_info
-            .read()
-            .version_ref_counts
-            .get(&version_number)
-            .unwrap_or(&0)
-            .clone()
-    }
-
-    /// Release the ref count for the version once the snapshot is no longer needed.
-    pub fn release_version(&self, version_number: u64) {
-        let mut versions_info_write = self.versions_info.write();
-        let count = *versions_info_write
-            .version_ref_counts
-            .get(&version_number)
-            .unwrap_or(&0);
-        versions_info_write
-            .version_ref_counts
-            .insert(version_number, count - 1);
-    }
-
-    /// This is thread-safe, and will increment the ref count for the version.
-    fn get_current_version_and_increment(&self) -> u64 {
-        let mut versions_info_write = self.versions_info.write();
-        let current_version = versions_info_write.current_version;
-
-        let count = *versions_info_write
-            .version_ref_counts
-            .get(&current_version)
-            .unwrap_or(&0);
-        versions_info_write
-            .version_ref_counts
-            .insert(current_version, count + 1);
-
-        current_version
     }
 
     pub fn get_all_segment_names(&self) -> Vec<String> {
-        self.all_segments
-            .iter()
-            .map(|pair| pair.key().clone())
-            .collect()
-    }
-
-    pub fn init_optimizing(&self, segments: &Vec<String>) -> Result<String> {
-        let random_name = format!("pending_segment_{}", rand::random::<u64>());
-        let pending_segment_path = format!("{}/{}", self.base_directory, random_name);
-        std::fs::create_dir_all(pending_segment_path.clone())?;
-        let mut current_segments = Vec::new();
-        for segment in segments {
-            current_segments.push(self.all_segments.get(segment).unwrap().clone());
+        match self {
+            BoxedCollection::CollectionNoQuantizationL2(collection) => collection.get_all_segment_names(),
+            BoxedCollection::CollectionProductQuantization(collection) => collection.get_all_segment_names(),
         }
-        let pending_segment =
-            PendingSegment::<Q>::new(current_segments.clone(), pending_segment_path);
-        let new_boxed_segment =
-            BoxedImmutableSegment::PendingSegment(Arc::new(RwLock::new(pending_segment)));
-        self.replace_segment_safe(new_boxed_segment, segments.clone(), true)?;
-
-        Ok(random_name)
     }
 
-    fn pending_to_finalized(
-        &self,
-        pending_segment: &str,
-        versions_info_read: RwLockUpgradableReadGuard<RawRwLock, VersionsInfo>,
-    ) -> Result<()> {
-        let random_name = format!("segment_{}", rand::random::<u64>());
-
-        // Hardlink the pending segment to the new segment
-        let pending_segment_path = format!("{}/{}", self.base_directory, pending_segment);
-        let new_segment_path = format!("{}/{}", self.base_directory, random_name);
-
-        // Create and copy content of the pending segment to the new segment
-        std::fs::create_dir_all(new_segment_path.clone())?;
-
-        let mut options = CopyOptions::default();
-        options.content_only = true;
-        fs_extra::dir::copy(
-            pending_segment_path.clone(),
-            new_segment_path.clone(),
-            &options,
-        )?;
-
-        // Replace the pending segment with the new segment
-        let index = MultiSpannReader::new(new_segment_path.clone()).read::<Q>()?;
-        let new_segment = BoxedImmutableSegment::FinalizedSegment(Arc::new(RwLock::new(
-            ImmutableSegment::new(index, random_name.clone()),
-        )));
-        self.replace_segment(
-            new_segment,
-            vec![pending_segment.to_string()],
-            false,
-            versions_info_read,
-        )?;
-        Ok(())
+    pub async fn process_one_op(&self) -> Result<usize> {
+        match self {
+            BoxedCollection::CollectionNoQuantizationL2(collection) => collection.process_one_op().await,
+            BoxedCollection::CollectionProductQuantization(collection) => collection.process_one_op().await,
+        }
     }
 
-    pub fn run_optimizer(
-        &self,
-        optimizer: &impl SegmentOptimizer,
-        pending_segment: &str,
-    ) -> Result<()> {
-        let x = self.all_segments.get(pending_segment).unwrap();
-        let segment = x.value().clone();
-        match segment {
-            BoxedImmutableSegment::PendingSegment(pending_segment) => {
-                let mut pending_segment = pending_segment.upgradable_read();
-                optimizer.optimize(&pending_segment)?;
-                pending_segment.build_index()?;
-                pending_segment.try_with_upgraded(|pending_segment_write| {
-                    pending_segment_write.apply_pending_deletions()?;
-                    pending_segment_write.switch_to_internal_index();
-                    Ok(())
-                });
+    pub fn get_snapshot(&self) -> Result<SnapshotWithQuantizer> {
+        match self {
+            BoxedCollection::CollectionNoQuantizationL2(collection) => {
+                let col = Arc::clone(collection);
+                let snapshot = col.get_snapshot()?;
+                Ok(SnapshotWithQuantizer::new_with_no_quantizer(snapshot))
             }
-            _ => {}
-        }
-
-        // Make the pending segment finalized
-        // Note that this function will upgrade toc lock.
-        let toc_locked = self.versions_info.upgradable_read();
-        self.pending_to_finalized(pending_segment, toc_locked)
-    }
-
-    fn trim_wal(&self, flushed_seq_no: i64) -> Result<()> {
-        if let Some(wal) = &self.wal {
-            wal.write().trim_wal(flushed_seq_no)?;
-        }
-        Ok(())
-    }
-}
-
-// Test
-#[cfg(test)]
-mod tests {
-
-    use std::sync::atomic::AtomicBool;
-    use std::sync::Arc;
-
-    use anyhow::{Ok, Result};
-    use config::collection::CollectionConfig;
-    use parking_lot::RwLock;
-    use quantization::noq::noq::NoQuantizerL2;
-    use rand::Rng;
-    use tempdir::TempDir;
-
-    use super::reader::CollectionReader;
-    use crate::collection::Collection;
-    use crate::optimizers::noop::NoopOptimizer;
-    use crate::segment::{BoxedImmutableSegment, MockedSegment, Segment};
-    use crate::utils::SearchContext;
-
-    #[test]
-    fn test_collection() -> Result<()> {
-        let temp_dir = TempDir::new("test_collection")?;
-        let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
-        let segment_config = CollectionConfig::default_test_config();
-        let collection = Arc::new(Collection::new(base_directory.clone(), segment_config).unwrap());
-
-        {
-            let segment1: BoxedImmutableSegment<NoQuantizerL2> =
-                BoxedImmutableSegment::MockedNoQuantizationSegment(Arc::new(RwLock::new(
-                    MockedSegment::new("segment1".to_string()),
-                )));
-            let segment2: BoxedImmutableSegment<NoQuantizerL2> =
-                BoxedImmutableSegment::MockedNoQuantizationSegment(Arc::new(RwLock::new(
-                    MockedSegment::new("segment2".to_string()),
-                )));
-
-            collection
-                .add_segments(
-                    vec!["segment1".to_string(), "segment2".to_string()],
-                    vec![segment1.clone(), segment2.clone()],
-                    0,
-                )
-                .unwrap();
-        }
-        let current_version = collection.current_version();
-        assert_eq!(current_version, 1);
-
-        let version_1 = 1;
-        {
-            let snapshot = collection.clone().get_snapshot()?;
-            assert_eq!(snapshot.segments.len(), 2);
-
-            let ref_count = collection.clone().get_ref_count(version_1);
-            assert_eq!(ref_count, 1);
-        }
-
-        // Snapshot should be dropped when it goes out of scope
-        let ref_count = collection.clone().get_ref_count(version_1);
-        assert_eq!(ref_count, 0);
-
-        // Create another snapshot, then add new segments
-        let version_2 = 2;
-        {
-            let snapshot = collection.clone().get_snapshot()?;
-            assert_eq!(snapshot.segments.len(), 2);
-            assert_eq!(snapshot.version(), 1);
-
-            collection
-                .add_segments(
-                    vec!["segment3".to_string(), "segment4".to_string()],
-                    vec![
-                        BoxedImmutableSegment::MockedNoQuantizationSegment(Arc::new(RwLock::new(
-                            MockedSegment::new("segment3".to_string()),
-                        ))),
-                        BoxedImmutableSegment::MockedNoQuantizationSegment(Arc::new(RwLock::new(
-                            MockedSegment::new("segment4".to_string()),
-                        ))),
-                    ],
-                    0,
-                )
-                .unwrap();
-
-            let ref_count = collection.clone().get_ref_count(version_1);
-            assert_eq!(ref_count, 1);
-
-            let ref_count = collection.clone().get_ref_count(version_2);
-            assert_eq!(ref_count, 0);
-        }
-
-        // Snapshot should be dropped when it goes out of scope
-        let ref_count = collection.clone().get_ref_count(version_1);
-        assert_eq!(ref_count, 0);
-        let ref_count = collection.clone().get_ref_count(version_2);
-        assert_eq!(ref_count, 0);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_collection_multi_thread() -> Result<()> {
-        let temp_dir = TempDir::new("test_collection")?;
-        let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
-        let segment_config = CollectionConfig::default_test_config();
-
-        let collection = Arc::new(Collection::new(base_directory.clone(), segment_config).unwrap());
-        let stopped = Arc::new(AtomicBool::new(false));
-
-        // Create a thread to add segments, and let it runs for a while
-        let stopped_cpy = stopped.clone();
-        let collection_cpy = collection.clone();
-        std::thread::spawn(move || {
-            let segment1 = BoxedImmutableSegment::MockedNoQuantizationSegment(Arc::new(
-                RwLock::new(MockedSegment::new("segment1".to_string())),
-            ));
-            let segment2 = BoxedImmutableSegment::MockedNoQuantizationSegment(Arc::new(
-                RwLock::new(MockedSegment::new("segment2".to_string())),
-            ));
-
-            collection_cpy
-                .add_segments(
-                    vec!["segment1".to_string(), "segment2".to_string()],
-                    vec![segment1.clone(), segment2.clone()],
-                    0,
-                )
-                .unwrap();
-
-            while !stopped_cpy.load(std::sync::atomic::Ordering::Relaxed) {
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }
-        });
-
-        // Sleep until there is a new version
-        let mut latest_version = collection.clone().current_version();
-        while latest_version != 1 {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            latest_version = collection.clone().current_version();
-        }
-
-        // Create another thread to get a snapshot
-        let collection_cpy = collection.clone();
-        let stopped_cpy = stopped.clone();
-        std::thread::spawn(move || {
-            let snapshot = collection_cpy.clone().get_snapshot().unwrap();
-            assert_eq!(snapshot.segments.len(), 2);
-            assert_eq!(snapshot.version(), 1);
-
-            let version_1 = 1;
-            let ref_count = collection_cpy.clone().get_ref_count(version_1);
-            assert_eq!(ref_count, 1);
-
-            while !stopped_cpy.load(std::sync::atomic::Ordering::Relaxed) {
-                assert_eq!(snapshot.version(), 1);
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }
-        });
-
-        // Sleep for 200ms, then check ref count
-        std::thread::sleep(std::time::Duration::from_millis(500));
-        let version_1 = 1;
-        let ref_count = collection.clone().get_ref_count(version_1);
-        assert_eq!(ref_count, 1);
-
-        std::thread::sleep(std::time::Duration::from_millis(500));
-        stopped.store(true, std::sync::atomic::Ordering::Relaxed);
-        Ok(())
-    }
-
-    #[test]
-    fn test_collection_optimizer() -> Result<()> {
-        let temp_dir = TempDir::new("test_collection")?;
-        let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
-        let segment_config = CollectionConfig::default_test_config();
-        let collection = Arc::new(Collection::new(base_directory.clone(), segment_config).unwrap());
-
-        // Add a document and flush
-        collection.insert_for_users(&[0], 1, &[1.0, 2.0, 3.0, 4.0], 0)?;
-        collection.flush()?;
-
-        let segment_names = collection.get_all_segment_names();
-        assert_eq!(segment_names.len(), 1);
-
-        let pending_segment = collection.init_optimizing(&segment_names)?;
-
-        let snapshot = collection.clone().get_snapshot()?;
-        assert_eq!(snapshot.segments.len(), 1);
-        assert_eq!(snapshot.version(), 2);
-        let segment_name = snapshot.segments[0].name();
-        assert_eq!(segment_name, pending_segment);
-
-        let mut context = SearchContext::new(false);
-        let result = snapshot
-            .search_for_ids(&[0], &[1.0, 2.0, 3.0, 4.0], 10, 10, &mut context)
-            .unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].id, 1);
-
-        let optimizer = NoopOptimizer::new();
-        collection.run_optimizer(&optimizer, &pending_segment)?;
-
-        let snapshot = collection.clone().get_snapshot()?;
-        assert_eq!(snapshot.segments.len(), 1);
-        assert_eq!(snapshot.version(), 3);
-
-        let toc = collection.get_current_toc();
-        assert_eq!(toc.toc.len(), 1);
-        assert_eq!(toc.pending.len(), 0);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_collection_multi_thread_optimizer() -> Result<()> {
-        let temp_dir = TempDir::new("test_collection")?;
-        let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
-        let segment_config = CollectionConfig::default_test_config();
-        let collection = Arc::new(Collection::new(base_directory.clone(), segment_config).unwrap());
-
-        collection.insert_for_users(&[0], 1, &[1.0, 2.0, 3.0, 4.0], 0)?;
-        collection.flush()?;
-
-        // A thread to optimize the segment
-        let collection_cpy_for_optimizer = collection.clone();
-        let collection_cpy_for_query = collection.clone();
-
-        let stopped = Arc::new(AtomicBool::new(false));
-        let stopped_cpy_for_optimizer = stopped.clone();
-        std::thread::spawn(move || {
-            while !stopped_cpy_for_optimizer.load(std::sync::atomic::Ordering::Relaxed) {
-                let c = collection_cpy_for_optimizer.clone();
-                let snapshot = c.get_snapshot().unwrap();
-                let segment_names = snapshot.segments.iter().map(|s| s.name()).collect();
-                let pending_segment = collection_cpy_for_optimizer
-                    .init_optimizing(&segment_names)
-                    .unwrap();
-
-                let toc = collection_cpy_for_optimizer.get_current_toc();
-                assert_eq!(toc.pending.len(), 1);
-
-                // Sleep randomly between 100ms and 200ms
-                let sleep_duration = rand::thread_rng().gen_range(100..200);
-                std::thread::sleep(std::time::Duration::from_millis(sleep_duration));
-
-                let optimizer = NoopOptimizer::new();
-                collection_cpy_for_optimizer
-                    .run_optimizer(&optimizer, &pending_segment)
-                    .unwrap();
-
-                let toc = collection_cpy_for_optimizer.get_current_toc();
-                assert_eq!(toc.pending.len(), 0);
-            }
-        });
-
-        // A thread to query the collection
-        let stopped_cpy_for_query = stopped.clone();
-        std::thread::spawn(move || {
-            while !stopped_cpy_for_query.load(std::sync::atomic::Ordering::Relaxed) {
-                let c = collection_cpy_for_query.clone();
-                let snapshot = c.get_snapshot().unwrap();
-                let mut context = SearchContext::new(false);
-                let result = snapshot
-                    .search_for_ids(&[0], &[1.0, 2.0, 3.0, 4.0], 10, 10, &mut context)
-                    .unwrap();
-                assert_eq!(result.len(), 1);
-                assert_eq!(result[0].id, 1);
-
-                // Sleep randomly between 100ms and 200ms
-                let sleep_duration = rand::thread_rng().gen_range(100..200);
-                std::thread::sleep(std::time::Duration::from_millis(sleep_duration));
-            }
-        });
-
-        // Sleep for 5 seconds, then stop the threads
-        std::thread::sleep(std::time::Duration::from_millis(5000));
-        stopped.store(true, std::sync::atomic::Ordering::Relaxed);
-        Ok(())
-    }
-
-    #[test]
-    fn test_collection_reader() -> Result<()> {
-        let temp_dir = TempDir::new("test_collection")?;
-        let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
-        let segment_config = CollectionConfig::default_test_config();
-        // write the collection config
-        let collection_config_path = format!("{}/collection_config.json", base_directory);
-        serde_json::to_writer_pretty(
-            std::fs::File::create(collection_config_path)?,
-            &segment_config,
-        )?;
-
-        {
-            let collection = Arc::new(Collection::<NoQuantizerL2>::new(
-                base_directory.clone(),
-                segment_config,
-            )
-            .unwrap());
-
-            collection.insert_for_users(&[0], 1, &[1.0, 2.0, 3.0, 4.0], 0)?;
-            collection.flush()?;
-
-            let segment_names = collection.get_all_segment_names();
-            assert_eq!(segment_names.len(), 1);
-
-            let pending_segment = collection.init_optimizing(&segment_names)?;
-
-            let toc = collection.get_current_toc();
-            assert_eq!(toc.pending.len(), 1);
-            assert_eq!(toc.pending.get(&pending_segment).unwrap().len(), 1);
-        }
-
-        let reader = CollectionReader::new(base_directory);
-        let collection = reader.read::<NoQuantizerL2>()?;
-        let toc = collection.get_current_toc();
-        assert_eq!(toc.pending.len(), 1);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_collection_with_wal() -> Result<()> {
-        let temp_dir = TempDir::new("test_collection")?;
-        let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
-        let mut segment_config = CollectionConfig::default_test_config();
-        segment_config.wal_file_size = 1024 * 1024;
-
-        let collection = Arc::new(
-            Collection::<NoQuantizerL2>::new(base_directory.clone(), segment_config).unwrap(),
-        );
-        collection
-            .write_to_wal(&[1], &[0], &[1.0, 2.0, 3.0, 4.0])
-            .await?;
-        collection
-            .write_to_wal(&[2], &[0], &[1.0, 2.0, 3.0, 4.0])
-            .await?;
-        collection
-            .write_to_wal(&[3], &[0], &[1.0, 2.0, 3.0, 4.0])
-            .await?;
-        collection
-            .write_to_wal(&[4], &[0], &[1.0, 2.0, 3.0, 4.0])
-            .await?;
-        collection
-            .write_to_wal(&[5], &[0], &[1.0, 2.0, 3.0, 4.0])
-            .await?;
-
-        // Process all ops
-        loop {
-            let op = collection.process_one_op().await?;
-            if op == 0 {
-                break;
+            BoxedCollection::CollectionProductQuantization(collection) => {
+                let col = Arc::clone(collection);
+                let snapshot = col.get_snapshot()?;
+                Ok(SnapshotWithQuantizer::new_with_product_quantizer(snapshot))
             }
         }
-        collection.flush()?;
-        let toc = collection.get_current_toc();
-        assert_eq!(toc.pending.len(), 0);
-        assert_eq!(toc.sequence_number, 4);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_collection_with_wal_reopen() -> Result<()> {
-        let temp_dir = TempDir::new("test_collection")?;
-        let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
-        let mut segment_config = CollectionConfig::default_test_config();
-        segment_config.wal_file_size = 1024 * 1024;
-
-        Collection::<NoQuantizerL2>::init_new_collection(base_directory.clone(), &segment_config)?;
-
-        // Insert but don't flush
-        {
-            let reader = CollectionReader::new(base_directory.clone());
-            let collection = reader.read::<NoQuantizerL2>()?;
-            collection
-                .write_to_wal(&[1], &[0], &[1.0, 2.0, 3.0, 4.0])
-                .await?;
-            collection
-                .write_to_wal(&[2], &[0], &[1.0, 2.0, 3.0, 4.0])
-                .await?;
-
-            // Process all ops
-            loop {
-                let op = collection.process_one_op().await?;
-                if op == 0 {
-                    break;
-                }
-            }
-        }
-
-        {
-            let reader = CollectionReader::new(base_directory.clone());
-            let collection = reader.read::<NoQuantizerL2>()?;
-            let toc = collection.get_current_toc();
-            assert_eq!(toc.pending.len(), 0);
-            assert_eq!(toc.sequence_number, -1);
-
-            collection.flush()?;
-            let toc = collection.get_current_toc();
-            assert_eq!(toc.pending.len(), 0);
-            assert_eq!(toc.sequence_number, 1);
-
-            // Write 2 more ops, but don't flush
-            collection
-                .write_to_wal(&[3], &[0], &[1.0, 2.0, 3.0, 4.0])
-                .await?;
-            collection
-                .write_to_wal(&[4], &[0], &[1.0, 2.0, 3.0, 4.0])
-                .await?;
-        }
-
-        {
-            let reader = CollectionReader::new(base_directory.clone());
-            let collection = reader.read::<NoQuantizerL2>()?;
-            let toc = collection.get_current_toc();
-            assert_eq!(toc.pending.len(), 0);
-            assert_eq!(toc.sequence_number, 1);
-
-            collection.flush()?;
-            let toc = collection.get_current_toc();
-            assert_eq!(toc.pending.len(), 0);
-            assert_eq!(toc.sequence_number, 3);
-        }
-
-        Ok(())
     }
 }

--- a/rs/index/src/collection/mod.rs
+++ b/rs/index/src/collection/mod.rs
@@ -202,15 +202,23 @@ impl BoxedCollection {
 
     pub fn get_all_segment_names(&self) -> Vec<String> {
         match self {
-            BoxedCollection::CollectionNoQuantizationL2(collection) => collection.get_all_segment_names(),
-            BoxedCollection::CollectionProductQuantization(collection) => collection.get_all_segment_names(),
+            BoxedCollection::CollectionNoQuantizationL2(collection) => {
+                collection.get_all_segment_names()
+            }
+            BoxedCollection::CollectionProductQuantization(collection) => {
+                collection.get_all_segment_names()
+            }
         }
     }
 
     pub async fn process_one_op(&self) -> Result<usize> {
         match self {
-            BoxedCollection::CollectionNoQuantizationL2(collection) => collection.process_one_op().await,
-            BoxedCollection::CollectionProductQuantization(collection) => collection.process_one_op().await,
+            BoxedCollection::CollectionNoQuantizationL2(collection) => {
+                collection.process_one_op().await
+            }
+            BoxedCollection::CollectionProductQuantization(collection) => {
+                collection.process_one_op().await
+            }
         }
     }
 

--- a/rs/index/src/collection/reader.rs
+++ b/rs/index/src/collection/reader.rs
@@ -2,11 +2,8 @@ use std::sync::Arc;
 
 use anyhow::{Ok, Result};
 use config::collection::CollectionConfig;
-use config::enums::QuantizerType;
 use parking_lot::RwLock;
-use quantization::noq::noq::NoQuantizer;
-use quantization::pq::pq::ProductQuantizer;
-use utils::distance::l2::L2DistanceCalculator;
+use quantization::quantization::Quantizer;
 use utils::io::get_latest_version;
 
 use super::{Collection, TableOfContent};
@@ -24,7 +21,7 @@ impl CollectionReader {
         Self { path }
     }
 
-    pub fn read(&self) -> Result<Arc<Collection>> {
+    pub fn read<Q: Quantizer + Clone>(&self) -> Result<Arc<Collection<Q>>> {
         // Read the SpannBuilderConfig
         let spann_builder_config_path = format!("{}/collection_config.json", self.path);
         let collection_config: CollectionConfig =
@@ -36,7 +33,7 @@ impl CollectionReader {
         let toc: TableOfContent = serde_json::from_reader(std::fs::File::open(toc_path)?)?;
 
         // Read the segments
-        let mut segments: Vec<BoxedImmutableSegment> = vec![];
+        let mut segments: Vec<BoxedImmutableSegment<Q>> = vec![];
         for name in &toc.toc {
             // We read pending segments later
             if toc.pending.contains_key(name) {
@@ -45,20 +42,10 @@ impl CollectionReader {
 
             let spann_path = format!("{}/{}", self.path, name);
             let spann_reader = MultiSpannReader::new(spann_path);
-            match collection_config.quantization_type {
-                QuantizerType::ProductQuantizer => {
-                    let index = spann_reader.read::<ProductQuantizer<L2DistanceCalculator>>()?;
-                    segments.push(BoxedImmutableSegment::FinalizedProductQuantizationSegment(
-                        Arc::new(RwLock::new(ImmutableSegment::new(index, name.clone()))),
-                    ));
-                }
-                QuantizerType::NoQuantizer => {
-                    let index = spann_reader.read::<NoQuantizer<L2DistanceCalculator>>()?;
-                    segments.push(BoxedImmutableSegment::FinalizedNoQuantizationSegment(
-                        Arc::new(RwLock::new(ImmutableSegment::new(index, name.clone()))),
-                    ));
-                }
-            };
+            let index = spann_reader.read::<Q>()?;
+            segments.push(BoxedImmutableSegment::FinalizedSegment(Arc::new(
+                RwLock::new(ImmutableSegment::new(index, name.clone())),
+            )));
         }
 
         // Empty all the pending segments
@@ -70,7 +57,7 @@ impl CollectionReader {
 
             // Get the inner segments
             let inner_segment_names = toc.pending.get(pending_segment_name).unwrap();
-            let mut inner_segments: Vec<BoxedImmutableSegment> = vec![];
+            let mut inner_segments: Vec<BoxedImmutableSegment<Q>> = vec![];
             for inner_segment_name in inner_segment_names {
                 for segment in &segments {
                     if segment.name() == *inner_segment_name {
@@ -80,24 +67,12 @@ impl CollectionReader {
                 }
             }
 
-            match collection_config.quantization_type {
-                QuantizerType::ProductQuantizer => {
-                    segments.push(BoxedImmutableSegment::PendingProductQuantizationSegment(
-                        Arc::new(RwLock::new(PendingSegment::new(
-                            inner_segments,
-                            pending_segment_path,
-                        ))),
-                    ));
-                }
-                QuantizerType::NoQuantizer => {
-                    segments.push(BoxedImmutableSegment::PendingNoQuantizationSegment(
-                        Arc::new(RwLock::new(PendingSegment::new(
-                            inner_segments,
-                            pending_segment_path,
-                        ))),
-                    ));
-                }
-            }
+            segments.push(BoxedImmutableSegment::PendingSegment(
+                Arc::new(RwLock::new(PendingSegment::new(
+                    inner_segments,
+                    pending_segment_path,
+                ))),
+            ));
         }
 
         let collection = Arc::new(Collection::init_from(
@@ -116,10 +91,12 @@ impl CollectionReader {
 mod tests {
     use anyhow::Result;
     use config::collection::CollectionConfig;
+    use quantization::noq::noq::NoQuantizerL2;
     use tempdir::TempDir;
     use utils::test_utils::generate_random_vector;
 
     use super::*;
+    use crate::collection::snapshot::Snapshot;
     use crate::multi_spann::builder::MultiSpannBuilder;
     use crate::multi_spann::writer::MultiSpannWriter;
 
@@ -191,7 +168,7 @@ mod tests {
         assert_eq!(collection.current_version(), 1);
 
         // Get current snapshot
-        let snapshot = collection.get_snapshot().unwrap();
+        let snapshot: Snapshot<NoQuantizerL2> = collection.get_snapshot().unwrap();
         assert_eq!(snapshot.segments.len(), 2);
     }
 }

--- a/rs/index/src/collection/reader.rs
+++ b/rs/index/src/collection/reader.rs
@@ -6,7 +6,8 @@ use parking_lot::RwLock;
 use quantization::quantization::Quantizer;
 use utils::io::get_latest_version;
 
-use super::{Collection, TableOfContent};
+use super::collection::Collection;
+use super::TableOfContent;
 use crate::multi_spann::reader::MultiSpannReader;
 use crate::segment::immutable_segment::ImmutableSegment;
 use crate::segment::pending_segment::PendingSegment;
@@ -67,12 +68,9 @@ impl CollectionReader {
                 }
             }
 
-            segments.push(BoxedImmutableSegment::PendingSegment(
-                Arc::new(RwLock::new(PendingSegment::new(
-                    inner_segments,
-                    pending_segment_path,
-                ))),
-            ));
+            segments.push(BoxedImmutableSegment::PendingSegment(Arc::new(
+                RwLock::new(PendingSegment::new(inner_segments, pending_segment_path)),
+            )));
         }
 
         let collection = Arc::new(Collection::init_from(

--- a/rs/index/src/collection/snapshot.rs
+++ b/rs/index/src/collection/snapshot.rs
@@ -1,22 +1,24 @@
 use std::sync::Arc;
 
+use quantization::quantization::Quantizer;
+
 use super::Collection;
 use crate::index::Searchable;
 use crate::segment::BoxedImmutableSegment;
 use crate::utils::{IdWithScore, SearchContext};
 
 /// Snapshot provides a view of the collection at a given point in time
-pub struct Snapshot {
-    pub segments: Vec<BoxedImmutableSegment>,
+pub struct Snapshot<Q: Quantizer + Clone> {
+    pub segments: Vec<BoxedImmutableSegment<Q>>,
     pub version: u64,
-    pub collection: Arc<Collection>,
+    pub collection: Arc<Collection<Q>>,
 }
 
-impl Snapshot {
+impl<Q: Quantizer + Clone> Snapshot<Q> {
     pub fn new(
-        segments: Vec<BoxedImmutableSegment>,
+        segments: Vec<BoxedImmutableSegment<Q>>,
         version: u64,
-        collection: Arc<Collection>,
+        collection: Arc<Collection<Q>>,
     ) -> Self {
         Self {
             segments,
@@ -55,7 +57,7 @@ impl Snapshot {
 }
 
 /// Search the collection using the given query
-impl Searchable for Snapshot {
+impl<Q: Quantizer + Clone> Searchable for Snapshot<Q> {
     fn search_with_id(
         &self,
         id: u128,
@@ -91,7 +93,7 @@ impl Searchable for Snapshot {
     }
 }
 
-impl Drop for Snapshot {
+impl<Q: Quantizer + Clone> Drop for Snapshot<Q> {
     fn drop(&mut self) {
         self.collection.release_version(self.version);
     }

--- a/rs/index/src/optimizers/engine.rs
+++ b/rs/index/src/optimizers/engine.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
 use anyhow::Result;
+use quantization::quantization::Quantizer;
 
 use super::noop::NoopOptimizer;
-use crate::collection::Collection;
+use crate::collection::collection::Collection;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum OptimizingType {
@@ -12,12 +13,12 @@ pub enum OptimizingType {
     Noop,
 }
 
-pub struct OptimizerEngine {
-    collection: Arc<Collection>,
+pub struct OptimizerEngine<Q: Quantizer + Clone> {
+    collection: Arc<Collection<Q>>,
 }
 
-impl OptimizerEngine {
-    pub fn new(collection: Arc<Collection>) -> Self {
+impl<Q: Quantizer + Clone> OptimizerEngine<Q> {
+    pub fn new(collection: Arc<Collection<Q>>) -> Self {
         Self { collection }
     }
 

--- a/rs/index/src/optimizers/mod.rs
+++ b/rs/index/src/optimizers/mod.rs
@@ -6,6 +6,6 @@ use quantization::quantization::Quantizer;
 
 use crate::segment::pending_segment::PendingSegment;
 
-pub trait SegmentOptimizer {
-    fn optimize<Q: Quantizer>(&self, segment: &PendingSegment<Q>) -> Result<()>;
+pub trait SegmentOptimizer<Q: Quantizer + Clone> {
+    fn optimize(&self, segment: &PendingSegment<Q>) -> Result<()>;
 }

--- a/rs/index/src/optimizers/noop.rs
+++ b/rs/index/src/optimizers/noop.rs
@@ -6,19 +6,23 @@ use super::SegmentOptimizer;
 use crate::segment::pending_segment::PendingSegment;
 use crate::segment::Segment;
 
-pub struct NoopOptimizer;
+pub struct NoopOptimizer<Q: Quantizer + Clone> {
+    _marker: std::marker::PhantomData<Q>,
+}
 
 /// This optimizer does nothing. It just copies the original segment to a new segment.
 /// Useful for testing the optimizer framework.
-impl NoopOptimizer {
+impl<Q: Quantizer + Clone> NoopOptimizer<Q> {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            _marker: std::marker::PhantomData,
+        }
     }
 }
 
 /// This optimizer does nothing. It just copies the original segment to a new segment.
-impl SegmentOptimizer for NoopOptimizer {
-    fn optimize<Q: Quantizer>(&self, segment: &PendingSegment<Q>) -> Result<()> {
+impl<Q: Quantizer + Clone> SegmentOptimizer<Q> for NoopOptimizer<Q> {
+    fn optimize(&self, segment: &PendingSegment<Q>) -> Result<()> {
         let inner_segments = segment.inner_segments();
         let data_directory = segment.base_directory();
 

--- a/rs/index/src/segment/mod.rs
+++ b/rs/index/src/segment/mod.rs
@@ -34,7 +34,6 @@ pub trait Segment {
     fn name(&self) -> String;
 }
 
-// TODO(hicder): Add different types of distance
 #[derive(Clone)]
 pub enum BoxedImmutableSegment<Q: Quantizer + Clone> {
     FinalizedSegment(Arc<RwLock<ImmutableSegment<Q>>>),
@@ -64,16 +63,12 @@ impl<Q: Quantizer + Clone> Searchable for BoxedImmutableSegment<Q> {
         context: &mut SearchContext,
     ) -> Option<Vec<IdWithScore>> {
         match self {
-            BoxedImmutableSegment::FinalizedSegment(immutable_segment) => {
-                immutable_segment
-                    .read()
-                    .search_with_id(id, query, k, ef_construction, context)
-            }
-            BoxedImmutableSegment::PendingSegment(pending_segment) => {
-                pending_segment
-                    .read()
-                    .search_with_id(id, query, k, ef_construction, context)
-            }
+            BoxedImmutableSegment::FinalizedSegment(immutable_segment) => immutable_segment
+                .read()
+                .search_with_id(id, query, k, ef_construction, context),
+            BoxedImmutableSegment::PendingSegment(pending_segment) => pending_segment
+                .read()
+                .search_with_id(id, query, k, ef_construction, context),
             BoxedImmutableSegment::MockedNoQuantizationSegment(mocked_segment) => mocked_segment
                 .read()
                 .search_with_id(id, query, k, ef_construction, context),
@@ -129,9 +124,7 @@ impl<Q: Quantizer + Clone> Segment for BoxedImmutableSegment<Q> {
             BoxedImmutableSegment::FinalizedSegment(immutable_segment) => {
                 immutable_segment.read().name()
             }
-            BoxedImmutableSegment::PendingSegment(pending_segment) => {
-                pending_segment.read().name()
-            }
+            BoxedImmutableSegment::PendingSegment(pending_segment) => pending_segment.read().name(),
             BoxedImmutableSegment::MockedNoQuantizationSegment(mocked_segment) => {
                 mocked_segment.read().name()
             }

--- a/rs/index/src/segment/mod.rs
+++ b/rs/index/src/segment/mod.rs
@@ -8,8 +8,7 @@ use anyhow::Result;
 use immutable_segment::ImmutableSegment;
 use parking_lot::RwLock;
 use pending_segment::PendingSegment;
-use quantization::noq::noq::NoQuantizerL2;
-use quantization::pq::pq::ProductQuantizerL2;
+use quantization::quantization::Quantizer;
 
 use crate::index::Searchable;
 use crate::utils::{IdWithScore, SearchContext};
@@ -37,18 +36,15 @@ pub trait Segment {
 
 // TODO(hicder): Add different types of distance
 #[derive(Clone)]
-pub enum BoxedImmutableSegment {
-    FinalizedNoQuantizationSegment(Arc<RwLock<ImmutableSegment<NoQuantizerL2>>>),
-    FinalizedProductQuantizationSegment(Arc<RwLock<ImmutableSegment<ProductQuantizerL2>>>),
-
-    PendingNoQuantizationSegment(Arc<RwLock<PendingSegment<NoQuantizerL2>>>),
-    PendingProductQuantizationSegment(Arc<RwLock<PendingSegment<ProductQuantizerL2>>>),
+pub enum BoxedImmutableSegment<Q: Quantizer + Clone> {
+    FinalizedSegment(Arc<RwLock<ImmutableSegment<Q>>>),
+    PendingSegment(Arc<RwLock<PendingSegment<Q>>>),
 
     // For tests
     MockedNoQuantizationSegment(Arc<RwLock<MockedSegment>>),
 }
 
-impl Searchable for BoxedImmutableSegment {
+impl<Q: Quantizer + Clone> Searchable for BoxedImmutableSegment<Q> {
     fn search(
         &self,
         query: &[f32],
@@ -68,104 +64,72 @@ impl Searchable for BoxedImmutableSegment {
         context: &mut SearchContext,
     ) -> Option<Vec<IdWithScore>> {
         match self {
-            BoxedImmutableSegment::FinalizedNoQuantizationSegment(immutable_segment) => {
+            BoxedImmutableSegment::FinalizedSegment(immutable_segment) => {
                 immutable_segment
                     .read()
                     .search_with_id(id, query, k, ef_construction, context)
             }
-            BoxedImmutableSegment::FinalizedProductQuantizationSegment(immutable_segment) => {
-                immutable_segment
+            BoxedImmutableSegment::PendingSegment(pending_segment) => {
+                pending_segment
                     .read()
                     .search_with_id(id, query, k, ef_construction, context)
             }
             BoxedImmutableSegment::MockedNoQuantizationSegment(mocked_segment) => mocked_segment
                 .read()
                 .search_with_id(id, query, k, ef_construction, context),
-            BoxedImmutableSegment::PendingNoQuantizationSegment(pending_segment) => pending_segment
-                .read()
-                .search_with_id(id, query, k, ef_construction, context),
-            BoxedImmutableSegment::PendingProductQuantizationSegment(pending_segment) => {
-                pending_segment
-                    .read()
-                    .search_with_id(id, query, k, ef_construction, context)
-            }
         }
     }
 }
 
-impl Segment for BoxedImmutableSegment {
+impl<Q: Quantizer + Clone> Segment for BoxedImmutableSegment<Q> {
     fn insert(&self, doc_id: u64, data: &[f32]) -> Result<()> {
         match self {
-            BoxedImmutableSegment::FinalizedNoQuantizationSegment(immutable_segment) => {
+            BoxedImmutableSegment::FinalizedSegment(immutable_segment) => {
                 immutable_segment.write().insert(doc_id, data)
             }
-            BoxedImmutableSegment::FinalizedProductQuantizationSegment(immutable_segment) => {
-                immutable_segment.write().insert(doc_id, data)
+            BoxedImmutableSegment::PendingSegment(pending_segment) => {
+                pending_segment.write().insert(doc_id, data)
             }
             BoxedImmutableSegment::MockedNoQuantizationSegment(mocked_segment) => {
                 mocked_segment.write().insert(doc_id, data)
-            }
-            BoxedImmutableSegment::PendingNoQuantizationSegment(pending_segment) => {
-                pending_segment.write().insert(doc_id, data)
-            }
-            BoxedImmutableSegment::PendingProductQuantizationSegment(pending_segment) => {
-                pending_segment.write().insert(doc_id, data)
             }
         }
     }
 
     fn remove(&self, doc_id: u64) -> Result<bool> {
         match self {
-            BoxedImmutableSegment::FinalizedNoQuantizationSegment(immutable_segment) => {
+            BoxedImmutableSegment::FinalizedSegment(immutable_segment) => {
                 immutable_segment.read().remove(doc_id)
             }
-            BoxedImmutableSegment::FinalizedProductQuantizationSegment(immutable_segment) => {
-                immutable_segment.read().remove(doc_id)
+            BoxedImmutableSegment::PendingSegment(pending_segment) => {
+                pending_segment.read().remove(doc_id)
             }
             BoxedImmutableSegment::MockedNoQuantizationSegment(mocked_segment) => {
                 mocked_segment.read().remove(doc_id)
-            }
-            BoxedImmutableSegment::PendingNoQuantizationSegment(pending_segment) => {
-                pending_segment.read().remove(doc_id)
-            }
-            BoxedImmutableSegment::PendingProductQuantizationSegment(pending_segment) => {
-                pending_segment.read().remove(doc_id)
             }
         }
     }
 
     fn may_contains(&self, doc_id: u64) -> bool {
         match self {
-            BoxedImmutableSegment::FinalizedNoQuantizationSegment(immutable_segment) => {
+            BoxedImmutableSegment::FinalizedSegment(immutable_segment) => {
                 immutable_segment.read().may_contains(doc_id)
             }
-            BoxedImmutableSegment::FinalizedProductQuantizationSegment(immutable_segment) => {
-                immutable_segment.read().may_contains(doc_id)
+            BoxedImmutableSegment::PendingSegment(pending_segment) => {
+                pending_segment.read().may_contains(doc_id)
             }
             BoxedImmutableSegment::MockedNoQuantizationSegment(mocked_segment) => {
                 mocked_segment.read().may_contains(doc_id)
-            }
-            BoxedImmutableSegment::PendingNoQuantizationSegment(pending_segment) => {
-                pending_segment.read().may_contains(doc_id)
-            }
-            BoxedImmutableSegment::PendingProductQuantizationSegment(pending_segment) => {
-                pending_segment.read().may_contains(doc_id)
             }
         }
     }
 
     fn name(&self) -> String {
         match self {
-            BoxedImmutableSegment::FinalizedNoQuantizationSegment(immutable_segment) => {
+            BoxedImmutableSegment::FinalizedSegment(immutable_segment) => {
                 immutable_segment.read().name()
             }
-            BoxedImmutableSegment::FinalizedProductQuantizationSegment(immutable_segment) => {
-                immutable_segment.read().name()
-            }
-            BoxedImmutableSegment::PendingNoQuantizationSegment(pending_segment) => {
-                pending_segment.read().name()
-            }
-            BoxedImmutableSegment::PendingProductQuantizationSegment(pending_segment) => {
+            BoxedImmutableSegment::PendingSegment(pending_segment) => {
                 pending_segment.read().name()
             }
             BoxedImmutableSegment::MockedNoQuantizationSegment(mocked_segment) => {
@@ -175,8 +139,8 @@ impl Segment for BoxedImmutableSegment {
     }
 }
 
-unsafe impl Send for BoxedImmutableSegment {}
-unsafe impl Sync for BoxedImmutableSegment {}
+unsafe impl<Q: Quantizer + Clone> Send for BoxedImmutableSegment<Q> {}
+unsafe impl<Q: Quantizer + Clone> Sync for BoxedImmutableSegment<Q> {}
 
 pub struct MockedSegment {
     name: String,

--- a/rs/index/src/segment/pending_segment.rs
+++ b/rs/index/src/segment/pending_segment.rs
@@ -143,8 +143,9 @@ mod tests {
     use std::sync::Arc;
 
     use config::collection::CollectionConfig;
-    use quantization::noq::noq::NoQuantizerL2;
+    use quantization::noq::noq::{NoQuantizer, NoQuantizerL2};
     use rand::Rng;
+    use utils::distance::l2::L2DistanceCalculator;
 
     use super::*;
     use crate::multi_spann::builder::MultiSpannBuilder;
@@ -191,9 +192,10 @@ mod tests {
         std::fs::create_dir_all(segment1_dir.clone()).unwrap();
         build_segment(segment1_dir.clone(), 0)?;
         let segment1 = read_segment(segment1_dir.clone())?;
-        let segment1 = BoxedImmutableSegment::<NoQuantizerL2>::FinalizedSegment(Arc::new(
-            RwLock::new(ImmutableSegment::new(segment1, "segment_1".to_string())),
-        ));
+        let segment1 =
+            BoxedImmutableSegment::<NoQuantizer<L2DistanceCalculator>>::FinalizedSegment(Arc::new(
+                RwLock::new(ImmutableSegment::new(segment1, "segment_1".to_string())),
+            ));
 
         let random_name = format!(
             "pending_segment_{}",
@@ -203,8 +205,10 @@ mod tests {
         std::fs::create_dir_all(pending_dir.clone()).unwrap();
 
         // Create a pending segment
-        let pending_segment =
-            PendingSegment::<NoQuantizerL2>::new(vec![segment1], pending_dir.clone());
+        let pending_segment = PendingSegment::<NoQuantizer<L2DistanceCalculator>>::new(
+            vec![segment1],
+            pending_dir.clone(),
+        );
 
         let mut context = SearchContext::new(false);
         let results = pending_segment.search_with_id(0, &[1.0, 2.0, 3.0, 4.0], 1, 10, &mut context);

--- a/rs/index_server/src/collection_catalog.rs
+++ b/rs/index_server/src/collection_catalog.rs
@@ -1,10 +1,9 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 
-use index::collection::Collection;
+use index::collection::BoxedCollection;
 
 pub struct CollectionCatalog {
-    collections: HashMap<String, Arc<Collection>>,
+    collections: HashMap<String, BoxedCollection>,
 }
 
 impl CollectionCatalog {
@@ -14,14 +13,14 @@ impl CollectionCatalog {
         }
     }
 
-    pub async fn add_collection(&mut self, name: String, collection: Arc<Collection>) {
+    pub async fn add_collection(&mut self, name: String, collection: BoxedCollection) {
         self.collections.insert(name, collection);
     }
 
-    pub async fn get_collection(&self, name: &str) -> Option<Arc<Collection>> {
+    pub async fn get_collection(&self, name: &str) -> Option<BoxedCollection> {
         self.collections
             .get(name)
-            .map(|collection| collection.clone())
+            .map(|collection| (*collection).clone())
     }
 
     pub async fn get_all_collection_names_sorted(&self) -> Vec<String> {

--- a/rs/index_server/src/collection_provider.rs
+++ b/rs/index_server/src/collection_provider.rs
@@ -1,7 +1,10 @@
-use std::sync::Arc;
-
+use config::collection::CollectionConfig;
+use config::enums::QuantizerType;
 use index::collection::reader::CollectionReader;
-use index::collection::Collection;
+use index::collection::BoxedCollection;
+use quantization::noq::noq::NoQuantizer;
+use quantization::pq::pq::ProductQuantizer;
+use utils::distance::l2::L2DistanceCalculator;
 
 pub struct CollectionProvider {
     data_directory: String,
@@ -12,14 +15,35 @@ impl CollectionProvider {
         Self { data_directory }
     }
 
-    pub fn read_collection(&self, name: &str) -> Option<Arc<Collection>> {
+    pub fn read_collection(&self, name: &str) -> Option<BoxedCollection> {
         let collection_path = format!("{}/{}", self.data_directory, name);
-        let reader = CollectionReader::new(collection_path);
-        match reader.read() {
-            Ok(collection) => Some(collection),
-            Err(e) => {
-                println!("Failed to read collection: {}", e);
-                None
+        let reader = CollectionReader::new(collection_path.clone());
+
+        // Read the collection config
+        let config_path = format!("{}/collection_config.json", collection_path);
+        let config = std::fs::read_to_string(config_path).unwrap();
+        let collection_config: CollectionConfig = serde_json::from_str(&config).unwrap();
+
+        match collection_config.quantization_type {
+            QuantizerType::NoQuantizer => {
+                match reader.read::<NoQuantizer<L2DistanceCalculator>>() {
+                    Ok(collection) => Some(BoxedCollection::CollectionNoQuantizationL2(collection)),
+                    Err(e) => {
+                        println!("Failed to read collection: {}", e);
+                        None
+                    }
+                }
+            }
+            QuantizerType::ProductQuantizer => {
+                match reader.read::<ProductQuantizer<L2DistanceCalculator>>() {
+                    Ok(collection) => {
+                        Some(BoxedCollection::CollectionProductQuantization(collection))
+                    }
+                    Err(e) => {
+                        println!("Failed to read collection: {}", e);
+                        None
+                    }
+                }
             }
         }
     }

--- a/rs/quantization/src/noq/noq.rs
+++ b/rs/quantization/src/noq/noq.rs
@@ -7,6 +7,7 @@ use utils::DistanceCalculator;
 
 use crate::quantization::{Quantizer, WritableQuantizer};
 
+#[derive(Debug, Clone, Copy)]
 pub struct NoQuantizer<D: DistanceCalculator> {
     dimension: usize,
 

--- a/rs/quantization/src/pq/pq.rs
+++ b/rs/quantization/src/pq/pq.rs
@@ -16,6 +16,7 @@ use crate::quantization::{Quantizer, WritableQuantizer};
 pub const CODEBOOK_NAME: &str = "codebook";
 
 // (TODO): support inner PQ distance template
+#[derive(Debug, Clone)]
 pub struct ProductQuantizer<D: DistanceCalculator> {
     pub dimension: usize,
     pub subvector_dimension: usize,

--- a/rs/utils/src/distance/l2.rs
+++ b/rs/utils/src/distance/l2.rs
@@ -13,6 +13,7 @@ pub enum L2DistanceCalculatorImpl {
     StreamingSIMD,
 }
 
+#[derive(Debug, Clone)]
 pub struct L2DistanceCalculator {}
 
 impl L2DistanceCalculator {


### PR DESCRIPTION
Previously, Quantizer template stays with segment. However, that means technically we can have multiple types of segments for a collection, which isn't right. This PR moves Quantizer template to collection.