### PR TITLE
Implement Merge Optimizer

### DIFF
--- a/rs/index/src/collection/collection.rs
+++ b/rs/index/src/collection/collection.rs
@@ -629,8 +629,11 @@ impl<Q: Quantizer + Clone> Collection<Q> {
         for segment in segments {
             current_segments.push(self.all_segments.get(segment).unwrap().clone());
         }
-        let pending_segment =
-            PendingSegment::<Q>::new(current_segments.clone(), pending_segment_path);
+        let pending_segment = PendingSegment::<Q>::new(
+            current_segments.clone(),
+            pending_segment_path,
+            self.segment_config.clone(),
+        );
         let new_boxed_segment =
             BoxedImmutableSegment::PendingSegment(Arc::new(RwLock::new(pending_segment)));
         self.replace_segment_safe(new_boxed_segment, segments.clone(), true)?;

--- a/rs/index/src/collection/reader.rs
+++ b/rs/index/src/collection/reader.rs
@@ -69,7 +69,11 @@ impl CollectionReader {
             }
 
             segments.push(BoxedImmutableSegment::PendingSegment(Arc::new(
-                RwLock::new(PendingSegment::new(inner_segments, pending_segment_path)),
+                RwLock::new(PendingSegment::new(
+                    inner_segments,
+                    pending_segment_path,
+                    collection_config.clone(),
+                )),
             )));
         }
 

--- a/rs/index/src/lib.rs
+++ b/rs/index/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(auto_traits)]
+#![feature(min_specialization)]
 
 pub mod collection;
 pub mod hnsw;

--- a/rs/index/src/optimizers/engine.rs
+++ b/rs/index/src/optimizers/engine.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Ok, Result};
 use quantization::quantization::Quantizer;
 
+use super::merge::MergeOptimizer;
 use super::noop::NoopOptimizer;
 use crate::collection::collection::Collection;
 
@@ -30,7 +31,12 @@ impl<Q: Quantizer + Clone> OptimizerEngine<Q> {
         let pending_segment = self.collection.init_optimizing(&segments)?;
         match optimizing_type {
             OptimizingType::Vacuum => Ok(()),
-            OptimizingType::Merge => Ok(()),
+            OptimizingType::Merge => {
+                let merge_optimizer = MergeOptimizer::<Q>::new();
+                self.collection
+                    .run_optimizer(&merge_optimizer, &pending_segment)?;
+                Ok(())
+            }
             OptimizingType::Noop => {
                 let noop_optimizer = NoopOptimizer::new();
                 self.collection

--- a/rs/index/src/optimizers/merge.rs
+++ b/rs/index/src/optimizers/merge.rs
@@ -1,0 +1,194 @@
+use anyhow::Result;
+use quantization::noq::noq::NoQuantizerL2;
+use quantization::quantization::Quantizer;
+
+use super::SegmentOptimizer;
+use crate::multi_spann::builder::MultiSpannBuilder;
+use crate::multi_spann::writer::MultiSpannWriter;
+use crate::segment::pending_segment::PendingSegment;
+
+pub struct MergeOptimizer<Q: Quantizer + Clone> {
+    _marker: std::marker::PhantomData<Q>,
+}
+
+impl<Q: Quantizer + Clone> MergeOptimizer<Q> {
+    pub fn new() -> Self {
+        Self {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<Q: Quantizer + Clone> SegmentOptimizer<Q> for MergeOptimizer<Q> {
+    #[allow(unused)]
+    default fn optimize(&self, segment: &PendingSegment<Q>) -> Result<()> {
+        Err(anyhow::anyhow!("not supported"))
+    }
+}
+
+impl SegmentOptimizer<NoQuantizerL2> for MergeOptimizer<NoQuantizerL2> {
+    fn optimize(&self, pending_segment: &PendingSegment<NoQuantizerL2>) -> Result<()> {
+        let inner_segments = pending_segment.inner_segments();
+        let all_user_ids = pending_segment.all_user_ids();
+
+        let config = pending_segment.collection_config();
+        let mut builder = MultiSpannBuilder::new(config.clone(), pending_segment.base_directory())?;
+
+        for user_id in all_user_ids {
+            for inner_segment in inner_segments {
+                let iter = inner_segment.iter_for_user(user_id);
+                if let Some(iter) = iter {
+                    for (doc_id, vector) in iter {
+                        builder.insert(user_id, doc_id, vector.as_slice())?;
+                    }
+                }
+            }
+        }
+
+        builder.build()?;
+        let writer = MultiSpannWriter::new(pending_segment.base_directory().clone());
+        writer.write(&mut builder)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use config::collection::CollectionConfig;
+
+    use super::*;
+    use crate::collection::collection::Collection;
+    use crate::collection::reader::CollectionReader;
+    use crate::utils::SearchContext;
+
+    #[test]
+    fn test_merge_optimizer() -> Result<()> {
+        let tmp_dir = tempdir::TempDir::new("test_merge_optimizer")?;
+        // Create directory if it doesn't exist
+        std::fs::create_dir_all(&tmp_dir)?;
+
+        let base_directory = tmp_dir.path().to_str().unwrap().to_string();
+        let mut config = CollectionConfig::default_test_config();
+        config.num_features = 3;
+        // Don't use WAL for this test
+        // Also, don't flush automatically
+        config.wal_file_size = 0;
+        config.max_time_to_flush_ms = 0;
+        config.max_pending_ops = 0;
+
+        Collection::<NoQuantizerL2>::init_new_collection(base_directory.clone(), &config)?;
+
+        let reader = CollectionReader::new(base_directory.clone());
+        let collection = reader.read::<NoQuantizerL2>()?;
+
+        collection.insert_for_users(&[0], 1, &[1.0, 2.0, 3.0], 0)?;
+        collection.insert_for_users(&[0], 2, &[4.0, 5.0, 6.0], 1)?;
+        collection.insert_for_users(&[0], 3, &[7.0, 8.0, 9.0], 2)?;
+
+        collection.flush()?;
+
+        collection.insert_for_users(&[0], 4, &[10.0, 11.0, 12.0], 3)?;
+        collection.insert_for_users(&[0], 5, &[13.0, 14.0, 15.0], 4)?;
+        collection.insert_for_users(&[0], 6, &[16.0, 17.0, 18.0], 5)?;
+
+        collection.flush()?;
+
+        // Now we have 2 segments, let merge them
+
+        let segments = collection.get_current_toc().toc.clone();
+        assert_eq!(segments.len(), 2);
+        let pending_segment = collection.init_optimizing(&segments)?;
+
+        let optimizer = MergeOptimizer::<NoQuantizerL2>::new();
+        collection.run_optimizer(&optimizer, &pending_segment)?;
+
+        let segments = collection.get_current_toc().toc.clone();
+        assert_eq!(segments.len(), 1);
+
+        let snapshot = collection.get_snapshot()?;
+        let mut context = SearchContext::new(false);
+        let result = snapshot
+            .search_for_ids(&[0], &[10.0, 11.0, 12.0], 3, 10, &mut context)
+            .unwrap();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].id, 4);
+        assert_eq!(result[1].id, 5);
+        assert_eq!(result[2].id, 6);
+
+        let result = snapshot
+            .search_for_ids(&[0], &[1.0, 2.0, 3.0], 3, 10, &mut context)
+            .unwrap();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].id, 1);
+        assert_eq!(result[1].id, 2);
+        assert_eq!(result[2].id, 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_merge_optimizer_with_multiple_users() -> Result<()> {
+        let tmp_dir = tempdir::TempDir::new("test_merge_optimizer")?;
+        // Create directory if it doesn't exist
+        std::fs::create_dir_all(&tmp_dir)?;
+
+        let base_directory = tmp_dir.path().to_str().unwrap().to_string();
+        let mut config = CollectionConfig::default_test_config();
+        config.num_features = 3;
+        config.initial_num_centroids = 1;
+        // Don't use WAL for this test
+        // Also, don't flush automatically
+        config.wal_file_size = 0;
+        config.max_time_to_flush_ms = 0;
+        config.max_pending_ops = 0;
+
+        Collection::<NoQuantizerL2>::init_new_collection(base_directory.clone(), &config)?;
+
+        let reader = CollectionReader::new(base_directory.clone());
+        let collection = reader.read::<NoQuantizerL2>()?;
+
+        collection.insert_for_users(&[0], 1, &[1.0, 2.0, 3.0], 0)?;
+        collection.insert_for_users(&[0], 2, &[4.0, 5.0, 6.0], 1)?;
+        collection.insert_for_users(&[0], 3, &[7.0, 8.0, 9.0], 2)?;
+
+        collection.flush()?;
+
+        collection.insert_for_users(&[1], 4, &[10.0, 11.0, 12.0], 3)?;
+        collection.insert_for_users(&[1], 5, &[13.0, 14.0, 15.0], 4)?;
+        collection.insert_for_users(&[1], 6, &[16.0, 17.0, 18.0], 5)?;
+
+        collection.flush()?;
+
+        // Now we have 2 segments, let merge them
+
+        let segments = collection.get_current_toc().toc.clone();
+        assert_eq!(segments.len(), 2);
+        let pending_segment = collection.init_optimizing(&segments)?;
+
+        let optimizer = MergeOptimizer::<NoQuantizerL2>::new();
+        collection.run_optimizer(&optimizer, &pending_segment)?;
+
+        let segments = collection.get_current_toc().toc.clone();
+        assert_eq!(segments.len(), 1);
+
+        let snapshot = collection.get_snapshot()?;
+        let mut context = SearchContext::new(false);
+        let result = snapshot
+            .search_for_ids(&[0], &[1.0, 2.0, 3.0], 3, 10, &mut context)
+            .unwrap();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].id, 1);
+        assert_eq!(result[1].id, 2);
+        assert_eq!(result[2].id, 3);
+
+        let result = snapshot
+            .search_for_ids(&[1], &[10.0, 11.0, 12.0], 3, 10, &mut context)
+            .unwrap();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].id, 4);
+        assert_eq!(result[1].id, 5);
+        assert_eq!(result[2].id, 6);
+
+        Ok(())
+    }
+}

--- a/rs/index/src/optimizers/mod.rs
+++ b/rs/index/src/optimizers/mod.rs
@@ -1,4 +1,5 @@
 pub mod engine;
+pub mod merge;
 pub mod noop;
 
 use anyhow::Result;

--- a/rs/index/src/optimizers/noop.rs
+++ b/rs/index/src/optimizers/noop.rs
@@ -23,8 +23,8 @@ impl<Q: Quantizer + Clone> NoopOptimizer<Q> {
 /// This optimizer does nothing. It just copies the original segment to a new segment.
 impl<Q: Quantizer + Clone> SegmentOptimizer<Q> for NoopOptimizer<Q> {
     fn optimize(&self, segment: &PendingSegment<Q>) -> Result<()> {
-        let inner_segments = segment.inner_segments();
-        let data_directory = segment.base_directory();
+        let inner_segments = segment.inner_segments_names();
+        let data_directory = segment.parent_directory();
 
         // Recursively copy everything from the data directory's inner segments to the new data directory.
         for inner_segment in inner_segments {

--- a/rs/index/src/segment/immutable_segment.rs
+++ b/rs/index/src/segment/immutable_segment.rs
@@ -5,6 +5,7 @@ use super::Segment;
 use crate::collection::SegmentSearchable;
 use crate::index::Searchable;
 use crate::multi_spann::index::MultiSpannIndex;
+use crate::spann::iter::SpannIter;
 
 /// This is an immutable segment. This usually contains a single index.
 pub struct ImmutableSegment<Q: Quantizer> {
@@ -15,6 +16,14 @@ pub struct ImmutableSegment<Q: Quantizer> {
 impl<Q: Quantizer> ImmutableSegment<Q> {
     pub fn new(index: MultiSpannIndex<Q>, name: String) -> Self {
         Self { index, name }
+    }
+
+    pub fn user_ids(&self) -> Vec<u128> {
+        self.index.user_ids()
+    }
+
+    pub fn iter_for_user(&self, user_id: u128) -> Option<SpannIter<Q>> {
+        self.index.iter_for_user(user_id)
     }
 }
 

--- a/rs/index/src/segment/mod.rs
+++ b/rs/index/src/segment/mod.rs
@@ -43,6 +43,34 @@ pub enum BoxedImmutableSegment<Q: Quantizer + Clone> {
     MockedNoQuantizationSegment(Arc<RwLock<MockedSegment>>),
 }
 
+impl<Q: Quantizer + Clone> BoxedImmutableSegment<Q> {
+    pub fn user_ids(&self) -> Vec<u128> {
+        match self {
+            BoxedImmutableSegment::FinalizedSegment(immutable_segment) => {
+                immutable_segment.read().user_ids()
+            }
+            BoxedImmutableSegment::PendingSegment(pending_segment) => {
+                pending_segment.read().all_user_ids()
+            }
+            BoxedImmutableSegment::MockedNoQuantizationSegment(mocked_segment) => {
+                mocked_segment.read().ids_to_return.clone()
+            }
+        }
+    }
+
+    pub fn iter_for_user(
+        &self,
+        user_id: u128,
+    ) -> Option<impl Iterator<Item = (u128, Vec<Q::QuantizedT>)>> {
+        match self {
+            BoxedImmutableSegment::FinalizedSegment(immutable_segment) => {
+                immutable_segment.read().iter_for_user(user_id)
+            }
+            _ => None,
+        }
+    }
+}
+
 impl<Q: Quantizer + Clone> Searchable for BoxedImmutableSegment<Q> {
     fn search(
         &self,

--- a/rs/index/src/spann/index.rs
+++ b/rs/index/src/spann/index.rs
@@ -9,6 +9,7 @@ use utils::distance::l2::L2DistanceCalculator;
 use crate::hnsw::index::Hnsw;
 use crate::index::Searchable;
 use crate::ivf::index::Ivf;
+use crate::utils::SearchContext;
 
 pub struct Spann<Q: Quantizer> {
     centroids: Hnsw<NoQuantizer<L2DistanceCalculator>>,
@@ -32,6 +33,27 @@ impl<Q: Quantizer> Spann<Q> {
 
     pub fn get_posting_lists(&self) -> &Ivf<Q, L2DistanceCalculator, PlainDecoder> {
         &self.posting_lists
+    }
+
+    pub fn get_doc_id(&self, point_id: u32) -> Option<u128> {
+        match self
+            .posting_lists
+            .index_storage
+            .get_doc_id(point_id as usize)
+        {
+            Ok(doc_id) => Some(doc_id),
+            Err(_) => None,
+        }
+    }
+
+    pub fn get_vector(
+        &self,
+        point_id: u32,
+        context: &mut SearchContext,
+    ) -> Option<&[Q::QuantizedT]> {
+        self.posting_lists
+            .vector_storage
+            .get(point_id as usize, context)
     }
 }
 

--- a/rs/index/src/spann/mod.rs
+++ b/rs/index/src/spann/mod.rs
@@ -1,4 +1,5 @@
 pub mod builder;
 pub mod index;
+pub mod iter;
 pub mod reader;
 pub mod writer;


### PR DESCRIPTION
Merge Optimizer for MuopDB. Note that we only support NoQuantization for merge for now.

With ProductQuantization, we need to store raw vectors in order to rebuild the new segment.