### PR TITLE
Avoid copying vector on iteration

### DIFF
--- a/rs/index/src/optimizers/merge.rs
+++ b/rs/index/src/optimizers/merge.rs
@@ -39,7 +39,7 @@ impl SegmentOptimizer<NoQuantizerL2> for MergeOptimizer<NoQuantizerL2> {
                 let iter = inner_segment.iter_for_user(user_id);
                 if let Some(iter) = iter {
                     let mut iter = iter;
-                    while let Some((doc_id, vector)) = iter.next_point() {
+                    while let Some((doc_id, vector)) = iter.next() {
                         builder.insert(user_id, doc_id, vector)?;
                     }
                 }

--- a/rs/index/src/optimizers/merge.rs
+++ b/rs/index/src/optimizers/merge.rs
@@ -38,8 +38,9 @@ impl SegmentOptimizer<NoQuantizerL2> for MergeOptimizer<NoQuantizerL2> {
             for inner_segment in inner_segments {
                 let iter = inner_segment.iter_for_user(user_id);
                 if let Some(iter) = iter {
-                    for (doc_id, vector) in iter {
-                        builder.insert(user_id, doc_id, vector.as_slice())?;
+                    let mut iter = iter;
+                    while let Some((doc_id, vector)) = iter.next_point() {
+                        builder.insert(user_id, doc_id, vector)?;
                     }
                 }
             }

--- a/rs/index/src/segment/mod.rs
+++ b/rs/index/src/segment/mod.rs
@@ -11,6 +11,7 @@ use pending_segment::PendingSegment;
 use quantization::quantization::Quantizer;
 
 use crate::index::Searchable;
+use crate::spann::iter::SpannIter;
 use crate::utils::{IdWithScore, SearchContext};
 
 /// A segment is a partial index: users can insert some documents, then flush
@@ -61,7 +62,7 @@ impl<Q: Quantizer + Clone> BoxedImmutableSegment<Q> {
     pub fn iter_for_user(
         &self,
         user_id: u128,
-    ) -> Option<impl Iterator<Item = (u128, Vec<Q::QuantizedT>)>> {
+    ) -> Option<SpannIter<Q>> {
         match self {
             BoxedImmutableSegment::FinalizedSegment(immutable_segment) => {
                 immutable_segment.read().iter_for_user(user_id)

--- a/rs/index/src/segment/mod.rs
+++ b/rs/index/src/segment/mod.rs
@@ -59,10 +59,7 @@ impl<Q: Quantizer + Clone> BoxedImmutableSegment<Q> {
         }
     }
 
-    pub fn iter_for_user(
-        &self,
-        user_id: u128,
-    ) -> Option<SpannIter<Q>> {
+    pub fn iter_for_user(&self, user_id: u128) -> Option<SpannIter<Q>> {
         match self {
             BoxedImmutableSegment::FinalizedSegment(immutable_segment) => {
                 immutable_segment.read().iter_for_user(user_id)

--- a/rs/index/src/spann/iter.rs
+++ b/rs/index/src/spann/iter.rs
@@ -19,19 +19,15 @@ impl<Q: Quantizer> SpannIter<Q> {
             search_context: SearchContext::new(false),
         }
     }
-}
 
-impl<Q: Quantizer> Iterator for SpannIter<Q> {
-    type Item = (u128, Vec<Q::QuantizedT>);
-
-    fn next(&mut self) -> Option<Self::Item> {
+    pub fn next_point(&mut self) -> Option<(u128, &[Q::QuantizedT])> {
         if let Some(doc_id) = self.index.get_doc_id(self.next_point_id) {
             let vector = self
                 .index
                 .get_vector(self.next_point_id, &mut self.search_context)
                 .unwrap();
             self.next_point_id += 1;
-            Some((doc_id, vector.to_vec()))
+            Some((doc_id, vector))
         } else {
             None
         }

--- a/rs/index/src/spann/iter.rs
+++ b/rs/index/src/spann/iter.rs
@@ -20,7 +20,7 @@ impl<Q: Quantizer> SpannIter<Q> {
         }
     }
 
-    pub fn next_point(&mut self) -> Option<(u128, &[Q::QuantizedT])> {
+    pub fn next(&mut self) -> Option<(u128, &[Q::QuantizedT])> {
         if let Some(doc_id) = self.index.get_doc_id(self.next_point_id) {
             let vector = self
                 .index


### PR DESCRIPTION
This saves a lot of memory allocation. We have to use manual iteration instead of the `Iterator` trait, since that's very hard to deal with lifetime.