### PR TITLE
Stub VectorStorage into IVF and HNSW

### DIFF
--- a/rs/index/src/hnsw/builder.rs
+++ b/rs/index/src/hnsw/builder.rs
@@ -230,7 +230,7 @@ impl<Q: Quantizer> HnswBuilder<Q> {
 
     /// Assign new ids to the vectors based on BFS on all layers
     fn get_reassigned_ids(&mut self) -> Result<Vec<i32>> {
-        let vector_length = self.vectors.len();
+        let vector_length = self.vectors.num_vectors();
         let mut assigned_ids = vec![-1; vector_length];
         let mut current_id = 0;
         let num_layers = self.layers.len();

--- a/rs/index/src/hnsw/index.rs
+++ b/rs/index/src/hnsw/index.rs
@@ -11,7 +11,7 @@ use utils::distance::l2::L2DistanceCalculatorImpl::StreamingSIMD;
 use super::utils::GraphTraversal;
 use crate::hnsw::writer::Header;
 use crate::utils::{IdWithScore, SearchContext};
-use crate::vector::fixed_file::FixedFileVectorStorage;
+use crate::vector::VectorStorage;
 
 pub struct Hnsw<Q: Quantizer> {
     // Need this for mmap
@@ -19,7 +19,7 @@ pub struct Hnsw<Q: Quantizer> {
     backing_file: File,
     mmap: Mmap,
 
-    pub vector_storage: FixedFileVectorStorage<Q::QuantizedT>,
+    pub vector_storage: Box<VectorStorage<Q::QuantizedT>>,
 
     header: Header,
     data_offset: usize,
@@ -35,7 +35,7 @@ pub struct Hnsw<Q: Quantizer> {
 impl<Q: Quantizer> Hnsw<Q> {
     pub fn new(
         backing_file: File,
-        vector_storage: FixedFileVectorStorage<Q::QuantizedT>,
+        vector_storage: Box<VectorStorage<Q::QuantizedT>>,
         header: Header,
         data_offset: usize,
         edges_offset: usize,

--- a/rs/index/src/ivf/writer.rs
+++ b/rs/index/src/ivf/writer.rs
@@ -53,8 +53,8 @@ where
         }
 
         let num_features = ivf_builder.config().num_features;
-        let num_clusters = ivf_builder.centroids().borrow().len();
-        let num_vectors = ivf_builder.vectors().borrow().len();
+        let num_clusters = ivf_builder.centroids().borrow().num_vectors();
+        let num_vectors = ivf_builder.vectors().borrow().num_vectors();
 
         // Write vectors
         let vectors_len = self
@@ -133,15 +133,18 @@ where
         // Write quantized vectors
         let path = format!("{}/vectors", self.base_directory);
         let mut file = File::create(path)?;
-        let capacity = full_vectors.borrow().len()
+        let capacity = full_vectors.borrow().num_vectors()
             * self.quantizer.quantized_dimension()
             * std::mem::size_of::<Q::QuantizedT>();
         let mut writer = BufWriter::with_capacity(min(1 << 30, capacity), &mut file);
 
         let mut bytes_written = 0;
-        bytes_written += wrap_write(&mut writer, &full_vectors.borrow().len().to_le_bytes())?;
+        bytes_written += wrap_write(
+            &mut writer,
+            &full_vectors.borrow().num_vectors().to_le_bytes(),
+        )?;
         let mut search_context = SearchContext::new(false);
-        for i in 0..full_vectors.borrow().len() {
+        for i in 0..full_vectors.borrow().num_vectors() {
             let quantized_vector = Q::QuantizedT::process_vector(
                 full_vectors.borrow().get(i as u32, &mut search_context)?,
                 &self.quantizer,

--- a/rs/index/src/multi_spann/builder.rs
+++ b/rs/index/src/multi_spann/builder.rs
@@ -113,7 +113,7 @@ mod tests {
             let builder = ref_multi.value().read().unwrap();
             match user_id {
                 1 => {
-                    assert_eq!(builder.ivf_builder.vectors().borrow().len(), 1);
+                    assert_eq!(builder.ivf_builder.vectors().borrow().num_vectors(), 1);
                     assert_eq!(
                         builder
                             .ivf_builder
@@ -134,7 +134,7 @@ mod tests {
                             .unwrap(),
                         0
                     );
-                    assert_eq!(builder.ivf_builder.centroids().borrow().len(), 1);
+                    assert_eq!(builder.ivf_builder.centroids().borrow().num_vectors(), 1);
                     assert_eq!(
                         builder
                             .ivf_builder
@@ -146,7 +146,7 @@ mod tests {
                     );
                 }
                 2 => {
-                    assert_eq!(builder.ivf_builder.vectors().borrow().len(), 1);
+                    assert_eq!(builder.ivf_builder.vectors().borrow().num_vectors(), 1);
                     assert_eq!(
                         builder
                             .ivf_builder
@@ -167,7 +167,7 @@ mod tests {
                             .unwrap(),
                         0
                     );
-                    assert_eq!(builder.ivf_builder.centroids().borrow().len(), 1);
+                    assert_eq!(builder.ivf_builder.centroids().borrow().num_vectors(), 1);
                     assert_eq!(
                         builder
                             .ivf_builder

--- a/rs/index/src/posting_list/file.rs
+++ b/rs/index/src/posting_list/file.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Result};
 use utils::io::wrap_write;
 use utils::mem::transmute_slice_to_u8;
 
-use super::{PostingList, PostingListStorage, PostingListStorageConfig};
+use super::{PostingList, PostingListStorageConfig};
 
 const PL_METADATA_LEN: usize = 2;
 
@@ -307,8 +307,8 @@ impl FileBackedAppendablePostingListStorage {
     }
 }
 
-impl<'a> PostingListStorage<'a> for FileBackedAppendablePostingListStorage {
-    fn get(&'a self, id: u32) -> Result<PostingList<'a>> {
+impl<'a> FileBackedAppendablePostingListStorage {
+    pub fn get(&'a self, id: u32) -> Result<PostingList<'a>> {
         let i = id as usize;
 
         if self.resident {
@@ -347,7 +347,7 @@ impl<'a> PostingListStorage<'a> for FileBackedAppendablePostingListStorage {
         )?)
     }
 
-    fn append(&mut self, posting_list: &[u64]) -> Result<()> {
+    pub fn append(&mut self, posting_list: &[u64]) -> Result<()> {
         let required_size = posting_list.len() * size_of::<u64>();
         self.size_bytes += required_size;
         let should_flush = self.resident && self.size_bytes > self.memory_threshold;
@@ -374,7 +374,7 @@ impl<'a> PostingListStorage<'a> for FileBackedAppendablePostingListStorage {
         Ok(())
     }
 
-    fn write(&mut self, writer: &mut BufWriter<&mut File>) -> Result<usize> {
+    pub fn write(&mut self, writer: &mut BufWriter<&mut File>) -> Result<usize> {
         let mut total_bytes_written = wrap_write(writer, &self.len().to_le_bytes())?;
 
         // If the data is still resident in memory, flush it to disk first
@@ -395,11 +395,11 @@ impl<'a> PostingListStorage<'a> for FileBackedAppendablePostingListStorage {
         Ok(total_bytes_written)
     }
 
-    fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.entry_count
     }
 
-    fn config(&self) -> PostingListStorageConfig {
+    pub fn config(&self) -> PostingListStorageConfig {
         PostingListStorageConfig {
             memory_threshold: self.memory_threshold,
             file_size: self.backing_file_size,

--- a/rs/index/src/posting_list/fixed_file.rs
+++ b/rs/index/src/posting_list/fixed_file.rs
@@ -57,7 +57,6 @@ mod tests {
 
     use super::*;
     use crate::posting_list::file::FileBackedAppendablePostingListStorage;
-    use crate::posting_list::PostingListStorage;
 
     #[test]
     fn test_fixed_file_posting_list_storage() {

--- a/rs/index/src/posting_list/mod.rs
+++ b/rs/index/src/posting_list/mod.rs
@@ -1,5 +1,3 @@
-use std::fs::File;
-use std::io::BufWriter;
 use std::mem::size_of;
 
 use anyhow::{anyhow, Result};
@@ -7,6 +5,7 @@ use anyhow::{anyhow, Result};
 pub mod combined_file;
 pub mod file;
 pub mod fixed_file;
+pub mod storage;
 
 /// Config for posting list storage.
 pub struct PostingListStorageConfig {
@@ -90,21 +89,4 @@ impl<'a> Iterator for PostingListIterator<'a> {
         }
         None
     }
-}
-
-/// Trait that defines the interface for posting list storage
-/// This storage owns the actual vectors, and will return a reference to it
-pub trait PostingListStorage<'a> {
-    fn get(&'a self, id: u32) -> Result<PostingList<'a>>;
-
-    fn append(&mut self, vector: &[u64]) -> Result<()>;
-
-    // Number of posting lists in the storage
-    fn len(&self) -> usize;
-
-    // Return number of bytes written.
-    fn write(&mut self, writer: &mut BufWriter<&mut File>) -> Result<usize>;
-
-    // Return the config for this posting list storage. Useful when we want duplicate.
-    fn config(&self) -> PostingListStorageConfig;
 }

--- a/rs/index/src/posting_list/storage.rs
+++ b/rs/index/src/posting_list/storage.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+
+use super::combined_file::{FixedIndexFile, Header};
+
+pub enum PostingListStorage {
+    FixedLocalFile(FixedIndexFile),
+}
+
+impl PostingListStorage {
+    pub fn new(base_directory: String) -> Self {
+        Self::FixedLocalFile(FixedIndexFile::new(base_directory).unwrap())
+    }
+
+    pub fn get_posting_list(&self, id: usize) -> Result<&[u8]> {
+        match self {
+            PostingListStorage::FixedLocalFile(storage) => storage.get_posting_list(id),
+        }
+    }
+
+    // Number of posting lists in the storage
+    pub fn len(&self) -> usize {
+        match self {
+            PostingListStorage::FixedLocalFile(storage) => storage.header().num_clusters as usize,
+        }
+    }
+
+    pub fn get_centroid(&self, id: usize) -> Result<&[f32]> {
+        match self {
+            PostingListStorage::FixedLocalFile(storage) => storage.get_centroid(id),
+        }
+    }
+
+    pub fn header(&self) -> &Header {
+        match self {
+            PostingListStorage::FixedLocalFile(storage) => storage.header(),
+        }
+    }
+
+    pub fn get_doc_id(&self, id: usize) -> Result<u128> {
+        match self {
+            PostingListStorage::FixedLocalFile(storage) => storage.get_doc_id(id),
+        }
+    }
+}

--- a/rs/index/src/spann/builder.rs
+++ b/rs/index/src/spann/builder.rs
@@ -184,7 +184,7 @@ impl SpannBuilder {
         debug!("Finish building IVF index");
 
         let centroid_storage = self.ivf_builder.centroids();
-        let num_centroids = centroid_storage.borrow().len();
+        let num_centroids = centroid_storage.borrow().num_vectors();
         let mut search_context = SearchContext::new(false);
 
         for i in 0..num_centroids {

--- a/rs/index/src/spann/reader.rs
+++ b/rs/index/src/spann/reader.rs
@@ -154,7 +154,7 @@ mod tests {
         let posting_lists = spann.get_posting_lists();
         assert_eq!(
             posting_lists.num_clusters(),
-            centroids.vector_storage.num_vectors
+            centroids.vector_storage.num_vectors()
         );
     }
 
@@ -215,7 +215,7 @@ mod tests {
         let posting_lists = spann.get_posting_lists();
         assert_eq!(
             posting_lists.num_clusters(),
-            centroids.vector_storage.num_vectors
+            centroids.vector_storage.num_vectors()
         );
         // Verify posting list content
         for i in 0..num_clusters {

--- a/rs/index/src/spann/writer.rs
+++ b/rs/index/src/spann/writer.rs
@@ -56,7 +56,7 @@ impl SpannWriter {
 
         debug!("Start training product quantizer");
         let sorted_random_rows = Self::get_sorted_random_rows(
-            ivf_builder.vectors().borrow().len(),
+            ivf_builder.vectors().borrow().num_vectors(),
             index_writer_config.pq_num_training_rows,
         );
 

--- a/rs/index/src/vector/file.rs
+++ b/rs/index/src/vector/file.rs
@@ -205,13 +205,13 @@ impl<T: ToBytes + Clone> FileBackedAppendableVectorStorage<T> {
         Ok(())
     }
 
-    pub fn len(&self) -> usize {
+    pub fn num_vectors(&self) -> usize {
         self.size_bytes / (self.num_features * std::mem::size_of::<T>())
     }
 
     // TODO(hicder): Just copy the backed file to the output file for optimization
     pub fn write(&self, writer: &mut std::io::BufWriter<&mut std::fs::File>) -> Result<usize> {
-        let num_vectors = self.len() as u64;
+        let num_vectors = self.num_vectors() as u64;
         let mut len = 0;
         len += wrap_write(writer, &num_vectors.to_le_bytes())?;
         for i in 0..num_vectors {
@@ -323,7 +323,7 @@ mod tests {
         }
 
         // Test length
-        assert_eq!(storage.len(), 12);
+        assert_eq!(storage.num_vectors(), 12);
 
         // Test flush
         assert!(storage.flush().is_ok());

--- a/rs/index/src/vector/fixed_file.rs
+++ b/rs/index/src/vector/fixed_file.rs
@@ -86,7 +86,7 @@ impl<T: ToBytes + Clone> FixedFileVectorStorage<T> {
         return Err(anyhow::anyhow!("Not supported"));
     }
 
-    pub fn len(&self) -> usize {
+    pub fn num_vectors(&self) -> usize {
         self.num_vectors
     }
 

--- a/rs/index/src/vector/mod.rs
+++ b/rs/index/src/vector/mod.rs
@@ -19,27 +19,6 @@ pub trait StorageContext {
     fn record_pages(&mut self, page_id: String);
 }
 
-/// Trait that defines the interface for vector storage
-/// This storage owns the actual vector, and will return a reference to it
-// pub trait VectorStorage<T: ToBytes + Clone> {
-//     fn get(&self, id: u32, context: &mut impl StorageContext) -> Result<&[T]>;
-
-//     // Get multiple vectors at once. This is useful for batch operations,
-//     // to avoid dynamic dispatch per point.
-//     fn multi_get(&self, ids: &[u32], context: &mut impl StorageContext) -> Result<Vec<&[T]>>;
-
-//     fn append(&mut self, vector: &[T]) -> Result<()>;
-
-//     // Number of vectors in the storage
-//     fn len(&self) -> usize;
-
-//     // Return number of bytes written.
-//     fn write(&self, writer: &mut BufWriter<&mut File>) -> Result<usize>;
-
-//     // Return the config for this vector storage. Useful when we want duplicate.
-//     fn config(&self) -> VectorStorageConfig;
-// }
-
 pub enum VectorStorage<T: ToBytes + Clone> {
     AppendableLocalFileBacked(file::FileBackedAppendableVectorStorage<T>),
     FixedLocalFileBacked(fixed_file::FixedFileVectorStorage<T>),
@@ -74,10 +53,10 @@ impl<T: ToBytes + Clone> VectorStorage<T> {
         }
     }
 
-    pub fn len(&self) -> usize {
+    pub fn num_vectors(&self) -> usize {
         match self {
-            VectorStorage::AppendableLocalFileBacked(storage) => storage.len(),
-            VectorStorage::FixedLocalFileBacked(storage) => storage.len(),
+            VectorStorage::AppendableLocalFileBacked(storage) => storage.num_vectors(),
+            VectorStorage::FixedLocalFileBacked(storage) => storage.num_vectors(),
         }
     }
 


### PR DESCRIPTION
Use `VectorStorage` instead of the implementations, in preparation for cloud storage