### PR TITLE
Use standard library ceil_div

### DIFF
--- a/rs/utils/src/lib.rs
+++ b/rs/utils/src/lib.rs
@@ -35,6 +35,7 @@ pub trait CalculateSquared {
     fn calculate_squared(a: &[f32], b: &[f32]) -> f32;
 }
 
+#[inline(always)]
 pub fn ceil_div(a: usize, b: usize) -> usize {
-    (a + b - 1) / b
+    a.div_ceil(b)
 }


### PR DESCRIPTION
Got a warning from compiler. Probably better to use this