### PR TITLE
Benchmark for OnDiskOrderedMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3367,6 +3367,7 @@ dependencies = [
  "rkyv",
  "strum",
  "tempdir",
+ "uuid",
 ]
 
 [[package]]
@@ -3374,6 +3375,9 @@ name = "uuid"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.2",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,4 @@ tonic = "0.12.3"
 tonic-build = "0.12.3"
 tonic-reflection = "0.12.3"
 utils = { path = './rs/utils' }
+uuid = {version = "1.16.0", features = ["v4"]}

--- a/rs/utils/Cargo.toml
+++ b/rs/utils/Cargo.toml
@@ -20,6 +20,7 @@ rayon.workspace = true
 rkyv.workspace = true
 strum.workspace = true
 tempdir.workspace = true
+uuid.workspace = true
 
 [[bench]]
 name = "l2"
@@ -35,6 +36,10 @@ harness = false
 
 [[bench]]
 name = "mem"
+harness = false
+
+[[bench]]
+name = "odom"
 harness = false
 
 [[bin]]

--- a/rs/utils/benches/odom.rs
+++ b/rs/utils/benches/odom.rs
@@ -1,0 +1,79 @@
+use std::fs::{self, File};
+
+use criterion::measurement::WallTime;
+use criterion::{
+    black_box, criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion,
+};
+use rand::Rng;
+use utils::on_disk_ordered_map::builder::OnDiskOrderedMapBuilder;
+use utils::on_disk_ordered_map::encoder::{FixedIntegerCodec, IntegerCodec, VarintIntegerCodec};
+use utils::on_disk_ordered_map::map::OnDiskOrderedMap;
+use uuid::Uuid;
+
+fn run_benchmark<C: IntegerCodec>(num_keys: usize, group: &mut BenchmarkGroup<WallTime>) {
+    // Create temporary directory for the test
+    let tmp_dir = tempdir::TempDir::new("bench_odom").unwrap();
+    fs::create_dir_all(tmp_dir.path()).unwrap();
+    let map_path = tmp_dir.path().join("test.odom");
+    let map_path_str = map_path.to_str().unwrap();
+
+    // Build the map
+    let mut builder = OnDiskOrderedMapBuilder::new();
+    let mut keys = Vec::with_capacity(num_keys);
+
+    // Generate and insert keys
+    for i in 0..num_keys {
+        let key = Uuid::new_v4().to_string();
+        builder.add(key.clone(), i as u64);
+        keys.push(key);
+    }
+
+    // Build the map with FixedIntegerCodec
+    builder.build(C::new(), map_path_str).unwrap();
+
+    // Open the map for reading
+    let file = File::open(&map_path).unwrap();
+    let mmap = unsafe { memmap2::Mmap::map(&file) }.unwrap();
+    let map = OnDiskOrderedMap::<C>::new(map_path_str.to_string(), &mmap, 0, mmap.len()).unwrap();
+
+    let mut rng = rand::thread_rng();
+
+    let codec = C::new();
+    let codec_name = match codec.id() {
+        0 => "FixedIntegerCodec",
+        1 => "VarintIntegerCodec",
+        _ => "UnknownCodec",
+    };
+    let bench_name = "Search/".to_owned() + codec_name;
+
+    group.bench_with_input(
+        BenchmarkId::new(bench_name, num_keys),
+        &num_keys,
+        |bencher, _| {
+            bencher.iter(|| {
+                let key_idx = rng.gen_range(0..keys.len());
+                let key = &keys[key_idx];
+                black_box(map.get(key).unwrap())
+            })
+        },
+    );
+}
+
+fn bench_odom(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ODOM");
+
+    for codec in [0, 1].iter() {
+        for num_keys in [16384, 32768, 65536].iter() {
+            if *codec == 0 {
+                run_benchmark::<FixedIntegerCodec>(*num_keys, &mut group);
+            } else {
+                run_benchmark::<VarintIntegerCodec>(*num_keys, &mut group);
+            }
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_odom);
+criterion_main!(benches);

--- a/rs/utils/src/on_disk_ordered_map/map.rs
+++ b/rs/utils/src/on_disk_ordered_map/map.rs
@@ -92,7 +92,7 @@ impl<'a, C: IntegerCodec> OnDiskOrderedMap<'a, C> {
     }
 
     #[allow(unused)]
-    fn get(&self, key: &str) -> Option<u64> {
+    pub fn get(&self, key: &str) -> Option<u64> {
         match self.index_for_key(key) {
             Some(offset) => {
                 let mut offset = self.data_offset + *offset as usize;


### PR DESCRIPTION
```
Compiling utils v0.1.0 (/Users/hieu/code/muopdb/rs/utils)
    Finished `bench` profile [optimized] target(s) in 0.92s
     Running benches/odom.rs (target/release/deps/odom-e013a31eb36dc562)
ODOM/Search/FixedIntegerCodec/16384
                        time:   [50.373 µs 50.629 µs 50.878 µs]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) low mild
  2 (2.00%) high mild
ODOM/Search/FixedIntegerCodec/32768
                        time:   [54.256 µs 54.525 µs 54.802 µs]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
ODOM/Search/FixedIntegerCodec/65536
                        time:   [69.708 µs 70.052 µs 70.417 µs]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
ODOM/Search/VarintIntegerCodec/16384
                        time:   [78.559 µs 78.960 µs 79.348 µs]
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
ODOM/Search/VarintIntegerCodec/32768
                        time:   [159.83 µs 163.50 µs 168.20 µs]
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
ODOM/Search/VarintIntegerCodec/65536
                        time:   [151.85 µs 152.99 µs 154.07 µs]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
```