### PR TITLE
Use invalidate_batch when applying pending deletions

### DIFF
--- a/rs/index/src/ivf/files/invalidated_ids.rs
+++ b/rs/index/src/ivf/files/invalidated_ids.rs
@@ -14,6 +14,7 @@ pub struct InvalidatedIdsStorage {
     current_offset: usize,
 }
 
+#[derive(PartialEq)]
 pub struct InvalidatedUserDocId {
     pub user_id: u128,
     pub doc_id: u128,

--- a/rs/index/src/ivf/index.rs
+++ b/rs/index/src/ivf/index.rs
@@ -91,6 +91,13 @@ impl<Q: Quantizer> IvfType<Q> {
         }
     }
 
+    pub fn invalidate_batch(&self, doc_ids: &[u128]) -> Vec<u128> {
+        match self {
+            IvfType::L2Plain(ivf) => ivf.invalidate_batch(doc_ids),
+            IvfType::L2EF(ivf) => ivf.invalidate_batch(doc_ids),
+        }
+    }
+
     pub fn is_invalidated(&self, doc_id: u128) -> bool {
         match self {
             IvfType::L2Plain(ivf) => ivf.is_invalidated(doc_id),

--- a/rs/index/src/segment/pending_segment.rs
+++ b/rs/index/src/segment/pending_segment.rs
@@ -124,14 +124,12 @@ impl<Q: Quantizer + Clone + Send + Sync> PendingSegment<Q> {
                 }
 
                 // TODO(tyb): hard link the storage? But still need to invalidate in the hash set
-                for (user_id, doc_ids) in self.temp_invalidated_ids.read().iter() {
-                    for doc_id in doc_ids {
-                        // doc_id may have been removed during optimizer run (e.g. we don't add
-                        // invalidated docs when merging), so we just need to make sure
-                        // invalidating doesn't result in error.
-                        let _ = index.invalidate(*user_id, *doc_id)?;
-                    }
-                }
+                //
+                // doc_id may have been removed during optimizer run (e.g. we don't add
+                // invalidated docs when merging), so we just need to make sure
+                // invalidating doesn't result in error, no need to verify the effectively
+                // invalidated element count.
+                let _ = index.invalidate_batch(&self.temp_invalidated_ids.read())?;
                 Ok(())
             }
             None => Err(anyhow!("Internal index does not exist")),

--- a/rs/index/src/spann/index.rs
+++ b/rs/index/src/spann/index.rs
@@ -63,6 +63,10 @@ impl<Q: Quantizer> Spann<Q> {
         self.posting_lists.invalidate(doc_id)
     }
 
+    pub fn invalidate_batch(&self, doc_ids: &[u128]) -> Vec<u128> {
+        self.posting_lists.invalidate_batch(doc_ids)
+    }
+
     pub fn is_invalidated(&self, doc_id: u128) -> bool {
         self.posting_lists.is_invalidated(doc_id)
     }


### PR DESCRIPTION
Using `invalidate_batch`
```
Vacuum/Vacuum/10000     time:   [1.1905 s 1.2054 s 1.2200 s]
```
Not using `invalidate_batch`
```
Vacuum/Vacuum/10000     time:   [3.3587 s 3.3992 s 3.4469 s]
```