### PR TITLE
get_point_id() should only be used for testing

### DIFF
--- a/rs/index/src/ivf/index.rs
+++ b/rs/index/src/ivf/index.rs
@@ -63,6 +63,8 @@ impl<Q: Quantizer> IvfType<Q> {
         }
     }
 
+    /// This is very expensive and should only be used for testing.
+    #[cfg(test)]
     pub fn get_point_id(&self, doc_id: u128) -> Option<u32> {
         match self {
             IvfType::L2Plain(ivf) => ivf.get_point_id(doc_id),

--- a/rs/index/src/multi_spann/index.rs
+++ b/rs/index/src/multi_spann/index.rs
@@ -167,6 +167,8 @@ impl<Q: Quantizer> MultiSpannIndex<Q> {
         Ok(index.is_invalidated(doc_id))
     }
 
+    /// This is very expensive and should only be used for testing.
+    #[cfg(test)]
     pub fn get_point_id(&self, user_id: u128, doc_id: u128) -> Option<u32> {
         match self.get_or_create_index(user_id) {
             Ok(index) => index.get_point_id(doc_id),

--- a/rs/index/src/segment/immutable_segment.rs
+++ b/rs/index/src/segment/immutable_segment.rs
@@ -29,6 +29,8 @@ impl<Q: Quantizer> ImmutableSegment<Q> {
         self.index.size_in_bytes()
     }
 
+    /// This is very expensive and should only be used for testing.
+    #[cfg(test)]
     pub fn get_point_id(&self, user_id: u128, doc_id: u128) -> Option<u32> {
         self.index.get_point_id(user_id, doc_id)
     }

--- a/rs/index/src/spann/index.rs
+++ b/rs/index/src/spann/index.rs
@@ -42,6 +42,8 @@ impl<Q: Quantizer> Spann<Q> {
             .ok()
     }
 
+    /// This is very expensive and should only be used for testing.
+    #[cfg(test)]
     pub fn get_point_id(&self, doc_id: u128) -> Option<u32> {
         self.posting_lists.get_point_id(doc_id)
     }


### PR DESCRIPTION
The current implementation is very slow and should not be used outside of IVF other for testing