### PR TITLE
feat: add fsync after WAL writes and create WAL insertion benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,9 +269,11 @@ dependencies = [
  "config",
  "criterion",
  "index",
+ "log",
  "quantization",
  "rand 0.8.5",
  "tempdir",
+ "tokio",
  "utils",
 ]
 

--- a/rs/benchmarks/Cargo.toml
+++ b/rs/benchmarks/Cargo.toml
@@ -18,6 +18,11 @@ name = "vacuum"
 path = "src/vacuum.rs"
 harness = false
 
+[[bench]]
+name = "wal_insertion"
+path = "src/wal_insertion.rs"
+harness = false
+
 [dependencies]
 utils.workspace = true
 criterion.workspace = true
@@ -26,3 +31,5 @@ config.workspace = true
 index.workspace = true
 quantization.workspace = true
 rand.workspace = true
+tokio.workspace = true
+log.workspace = true

--- a/rs/benchmarks/src/wal_insertion.rs
+++ b/rs/benchmarks/src/wal_insertion.rs
@@ -1,0 +1,128 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use config::collection::CollectionConfig;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use index::collection::collection::Collection;
+use index::collection::reader::CollectionReader;
+use index::wal::entry::WalOpType;
+use quantization::noq::noq::NoQuantizerL2;
+use tempdir::TempDir;
+use tokio;
+use utils::test_utils::generate_random_vector;
+
+fn bench_wal_insertion(c: &mut Criterion) {
+    let mut group = c.benchmark_group("WalInsertion");
+    // Run only 10 iterations since it's pretty slow
+    group.sample_size(10);
+
+    let collection_name = "test_collection_wal";
+    let temp_dir = TempDir::new(collection_name).expect("Failed to create temporary directory");
+    let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
+    let mut segment_config = CollectionConfig::default();
+    segment_config.num_features = 128;
+    // Enable WAL for this benchmark
+    segment_config.wal_file_size = 1024 * 1024; // 1MB WAL file size
+
+    // Create the collection outside of the benchmark
+    // Remove everything under base_directory
+    std::fs::remove_dir_all(&base_directory).unwrap();
+
+    // init the collection
+    Collection::<NoQuantizerL2>::init_new_collection(base_directory.clone(), &segment_config)
+        .unwrap();
+    let reader = CollectionReader::new(collection_name.to_string(), base_directory.clone());
+    let collection = reader.read::<NoQuantizerL2>().unwrap();
+
+    // Start background thread to process pending operations outside of benchmark
+    let running = Arc::new(AtomicBool::new(true));
+    let running_clone = running.clone();
+    let collection_clone = collection.clone();
+    let background_thread = thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        while running_clone.load(Ordering::Relaxed) {
+            // Process pending operations in a blocking context
+            let _ = rt.block_on(async {
+                loop {
+                    let processed = collection_clone.process_one_op().await.unwrap();
+                    if processed == 0 {
+                        break;
+                    }
+                }
+            });
+            // Small delay to prevent busy looping
+            thread::sleep(Duration::from_millis(1));
+        }
+    });
+
+    let num_vectors = 1000;
+    let num_features = segment_config.num_features;
+    let vectors = (0..num_vectors)
+        .map(|_| generate_random_vector(num_features))
+        .collect::<Vec<_>>();
+    let user_ids = vec![0];
+
+    group.bench_with_input(
+        BenchmarkId::new("WalInsertion", 1000),
+        &1000,
+        |bencher, _| {
+            bencher.iter(|| {
+                // Create a vector to store thread handles
+                let mut handles = vec![];
+
+                // Number of threads and documents per thread
+                const NUM_THREADS: usize = 10;
+                const DOCS_PER_THREAD: usize = 100;
+
+                // Clone the collection for each thread
+                let collection_clones: Vec<_> =
+                    (0..NUM_THREADS).map(|_| collection.clone()).collect();
+
+                // Spawn 10 threads, each handling 100 document IDs
+                for thread_idx in 0..NUM_THREADS {
+                    let collection_clone = collection_clones[thread_idx].clone();
+                    let user_ids_clone = user_ids.clone();
+                    let vectors_clone = vectors.clone();
+
+                    let handle = std::thread::spawn(move || {
+                        // Create a Tokio runtime for each thread
+                        let rt = tokio::runtime::Runtime::new().unwrap();
+                        let start_doc_id = thread_idx * DOCS_PER_THREAD;
+                        let end_doc_id = start_doc_id + DOCS_PER_THREAD;
+
+                        for doc_id in start_doc_id..end_doc_id {
+                            let vector = &vectors_clone[doc_id];
+                            // Use write_to_wal instead of insert_for_users
+                            // This is the only operation being measured in the benchmark
+                            rt.block_on(collection_clone.write_to_wal(
+                                &[doc_id as u128],
+                                &user_ids_clone,
+                                vector,
+                                WalOpType::Insert,
+                            ))
+                            .unwrap();
+                        }
+                    });
+
+                    handles.push(handle);
+                }
+
+                // Wait for all threads to complete
+                for handle in handles {
+                    handle.join().unwrap();
+                }
+            });
+        },
+    );
+
+    // Stop the background thread
+    running.store(false, Ordering::Relaxed);
+    background_thread.join().unwrap();
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_wal_insertion);
+criterion_main!(benches);

--- a/rs/index/src/collection/collection.rs
+++ b/rs/index/src/collection/collection.rs
@@ -1106,7 +1106,6 @@ mod tests {
 
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
-    use std::time::Instant;
 
     use anyhow::{Ok, Result};
     use config::collection::CollectionConfig;

--- a/rs/index/src/wal/file.rs
+++ b/rs/index/src/wal/file.rs
@@ -104,6 +104,7 @@ impl WalFile {
         self.file.write_all(transmute_slice_to_u8(data))?;
         self.file.write_all(&(op_type as u8).to_le_bytes())?;
         self.file.flush()?;
+        self.file.sync_data()?;
 
         // Increment the number of entries in the file
         self.num_entries += 1;
@@ -116,6 +117,7 @@ impl WalFile {
         self.file.write_all(&length.to_le_bytes())?;
         self.file.write_all(data)?;
         self.file.flush()?;
+        self.file.sync_data()?;
 
         // Increment the number of entries in the file
         self.num_entries += 1;


### PR DESCRIPTION
```
Benchmarking WalInsertion/WalInsertion/1000: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 40.7s.
WalInsertion/WalInsertion/1000
                        time:   [4.0950 s 4.1411 s 4.1856 s]
                        change: [+3.4096% +5.0006% +6.4060%] (p = 0.00 < 0.05)
                        Performance has regressed.
```