### PR TITLE
perf: let CollectionManager own CollectionCatalog

### DIFF
--- a/rs/index/src/segment/mutable_segment.rs
+++ b/rs/index/src/segment/mutable_segment.rs
@@ -68,7 +68,7 @@ impl MutableSegment {
 
         // Process document attributes if present
         if let Some(attributes) = document_attribute {
-            let mut tokenizer = WhiteSpaceTokenizer {};
+            let tokenizer = WhiteSpaceTokenizer {};
             let mut term_builder = self.term_builder.lock().unwrap();
             let doc_id_u64 = doc_id as u64;
 

--- a/rs/index/src/terms/builder.rs
+++ b/rs/index/src/terms/builder.rs
@@ -39,7 +39,7 @@ impl TermBuilder {
         }
 
         let term_id = self.persist_and_get_term_id(key);
-        self.scratch_file.write(doc_id, term_id).unwrap();
+        self.scratch_file.write(doc_id, term_id)?;
         self.posting_lists
             .entry(term_id)
             .or_insert_with(Vec::new)

--- a/rs/index/src/tokenizer/tokenizer.rs
+++ b/rs/index/src/tokenizer/tokenizer.rs
@@ -20,5 +20,5 @@ pub trait TokenStream {
 pub trait Tokenizer {
     type TokenStream<'a>: TokenStream;
 
-    fn input<'a>(&mut self, text: &'a str) -> Self::TokenStream<'a>;
+    fn input<'a>(&self, text: &'a str) -> Self::TokenStream<'a>;
 }

--- a/rs/index/src/tokenizer/white_space_tokenizer.rs
+++ b/rs/index/src/tokenizer/white_space_tokenizer.rs
@@ -7,7 +7,7 @@ pub struct WhiteSpaceTokenizer {}
 impl Tokenizer for WhiteSpaceTokenizer {
     type TokenStream<'a> = WhiteSpaceTokenStream<'a>;
 
-    fn input<'a>(&mut self, text: &'a str) -> WhiteSpaceTokenStream<'a> {
+    fn input<'a>(&self, text: &'a str) -> WhiteSpaceTokenStream<'a> {
         WhiteSpaceTokenStream::new(text)
     }
 }
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn test_tokenizer() {
-        let mut tokenizer = WhiteSpaceTokenizer {};
+        let tokenizer = WhiteSpaceTokenizer {};
         let mut token_stream: WhiteSpaceTokenStream<'_> =
             tokenizer.input("   .  happy      new  year ");
         let mut tokens: Vec<String> = vec![];

--- a/rs/index_server/src/admin_server.rs
+++ b/rs/index_server/src/admin_server.rs
@@ -60,8 +60,7 @@ impl IndexServerAdmin for AdminServerImpl {
             }
         } else {
             return Err(tonic::Status::not_found(format!(
-                "Collection {} not found",
-                collection_name
+                "Collection {collection_name} not found"
             )));
         }
 
@@ -98,7 +97,7 @@ impl IndexServerAdmin for AdminServerImpl {
                     .collect();
                 let end = std::time::Instant::now();
                 let duration = end.duration_since(start);
-                info!("[{}] Get segments in {:?}", collection_name, duration);
+                info!("[{collection_name}] Get segments in {duration:?}");
 
                 Ok(tonic::Response::new(GetSegmentsResponse {
                     segment_infos: returned_segment_infos,

--- a/rs/index_server/src/admin_server.rs
+++ b/rs/index_server/src/admin_server.rs
@@ -8,17 +8,17 @@ use proto::admin::{
     GetSegmentsRequest, GetSegmentsResponse, MergeSegmentsRequest, MergeSegmentsResponse,
     SegmentInfo,
 };
-use tokio::sync::Mutex;
+use tokio::sync::RwLock;
 
-use crate::collection_catalog::CollectionCatalog;
+use crate::collection_manager::CollectionManager;
 
 pub struct AdminServerImpl {
-    pub collection_catalog: Arc<Mutex<CollectionCatalog>>,
+    collection_manager: Arc<RwLock<CollectionManager>>,
 }
 
 impl AdminServerImpl {
-    pub fn new(collection_catalog: Arc<Mutex<CollectionCatalog>>) -> Self {
-        Self { collection_catalog }
+    pub fn new(collection_manager: Arc<RwLock<CollectionManager>>) -> Self {
+        Self { collection_manager }
     }
 }
 
@@ -33,8 +33,8 @@ impl IndexServerAdmin for AdminServerImpl {
         let segment_names = req.segment_names;
         let returned_segment_name;
         if let Some(collection) = self
-            .collection_catalog
-            .lock()
+            .collection_manager
+            .read()
             .await
             .get_collection(&collection_name)
             .await
@@ -79,8 +79,8 @@ impl IndexServerAdmin for AdminServerImpl {
         let collection_name = req.collection_name;
 
         let collection_opt = self
-            .collection_catalog
-            .lock()
+            .collection_manager
+            .read()
             .await
             .get_collection(&collection_name)
             .await;

--- a/rs/index_server/src/collection_manager.rs
+++ b/rs/index_server/src/collection_manager.rs
@@ -76,8 +76,7 @@ impl CollectionManager {
                         collection_name
                     ),
                     &collection_config,
-                )
-                .unwrap();
+                )?;
             }
             QuantizerType::ProductQuantizer => {
                 Collection::<ProductQuantizerL2>::init_new_collection(
@@ -87,8 +86,7 @@ impl CollectionManager {
                         collection_name
                     ),
                     &collection_config,
-                )
-                .unwrap();
+                )?;
             }
         }
 

--- a/rs/index_server/src/index_server.rs
+++ b/rs/index_server/src/index_server.rs
@@ -298,12 +298,12 @@ impl IndexServer for IndexServerImpl {
 
                 vectors
                     .chunks(dimensions)
-                    .zip(&ids)
+                    .zip(ids)
                     .zip(doc_attrs)
                     .for_each(|((vector, id), doc_attr)| {
                         // TODO(hicder): Handle errors
                         collection
-                            .insert_for_users(&user_ids, *id, vector, seq_no, doc_attr)
+                            .insert_for_users(&user_ids, id, vector, seq_no, doc_attr)
                             .unwrap()
                     });
 

--- a/rs/index_server/src/main.rs
+++ b/rs/index_server/src/main.rs
@@ -19,7 +19,7 @@ use proto::admin::index_server_admin_server::IndexServerAdminServer;
 use proto::muopdb::index_server_server::IndexServerServer;
 use proto::muopdb::FILE_DESCRIPTOR_SET;
 use tokio::spawn;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::RwLock;
 use tokio::time::sleep;
 use tonic::transport::Server;
 


### PR DESCRIPTION
This PR refactors the ownership model so that `CollectionManager` completely owns the `CollectionCatalog`. All server components (`IndexServerImpl` and `AdminServerImpl`) now only need to hold an `Arc<RwLock<CollectionManager>>` and access collections through the manager's API. 

This refactor allows multiple threads concurrently read the collection catalog. Previously, the catalog was wrapped in a `Mutex`, which forced all reads and writes to be exclusive and blocked each other.

Now `CollectionManager` is the single point of access for all collection-related operations, resulting in a cleaner and more maintainable architecture. 
