### PR TITLE
perf: Increase thread count in wal_insertion bench

### DIFF
--- a/rs/benchmarks/src/wal_insertion.rs
+++ b/rs/benchmarks/src/wal_insertion.rs
@@ -88,8 +88,8 @@ fn bench_wal_insertion(c: &mut Criterion) {
                 let mut handles = vec![];
 
                 // Number of threads and documents per thread
-                const NUM_THREADS: usize = 40;
-                const DOCS_PER_THREAD: usize = 25;
+                const NUM_THREADS: usize = 100;
+                const DOCS_PER_THREAD: usize = 10;
 
                 // Clone the collection for each thread
                 let collection_clones: Vec<_> =


### PR DESCRIPTION
More threads increase throughput
```
Benchmarking WalInsertion/WalInsertion/1000: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.4s or enable flat sampling.
WalInsertion/WalInsertion/1000
                        time:   [96.019 ms 98.638 ms 102.79 ms]
                        change: [-43.115% -40.816% -38.320%] (p = 0.00 < 0.05)
                        Performance has improved.
```