### PR TITLE
perf: Implement WAL write groups for appending WAL data 

### DIFF
--- a/rs/benchmarks/src/deletion_and_vacuum.rs
+++ b/rs/benchmarks/src/deletion_and_vacuum.rs
@@ -1,6 +1,6 @@
 use config::collection::CollectionConfig;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use index::collection::collection::Collection;
+use index::collection::core::Collection;
 use index::collection::reader::CollectionReader;
 use index::optimizers::vacuum::VacuumOptimizer;
 use quantization::noq::noq::NoQuantizerL2;

--- a/rs/benchmarks/src/insertion.rs
+++ b/rs/benchmarks/src/insertion.rs
@@ -1,6 +1,6 @@
 use config::collection::CollectionConfig;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use index::collection::collection::Collection;
+use index::collection::core::Collection;
 use index::collection::reader::CollectionReader;
 use quantization::noq::noq::NoQuantizerL2;
 use tempdir::TempDir;

--- a/rs/benchmarks/src/vacuum.rs
+++ b/rs/benchmarks/src/vacuum.rs
@@ -1,6 +1,6 @@
 use config::collection::CollectionConfig;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use index::collection::collection::Collection;
+use index::collection::core::Collection;
 use index::collection::reader::CollectionReader;
 use index::optimizers::vacuum::VacuumOptimizer;
 use quantization::noq::noq::NoQuantizerL2;

--- a/rs/benchmarks/src/wal_insertion.rs
+++ b/rs/benchmarks/src/wal_insertion.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use config::collection::CollectionConfig;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use index::collection::collection::Collection;
+use index::collection::core::Collection;
 use index::collection::reader::CollectionReader;
 use index::wal::entry::WalOpType;
 use quantization::noq::noq::NoQuantizerL2;

--- a/rs/benchmarks/src/wal_insertion.rs
+++ b/rs/benchmarks/src/wal_insertion.rs
@@ -10,6 +10,7 @@ use index::collection::reader::CollectionReader;
 use index::wal::entry::WalOpType;
 use quantization::noq::noq::NoQuantizerL2;
 use tempdir::TempDir;
+use tokio::task::JoinSet;
 use utils::test_utils::generate_random_vector;
 
 fn bench_wal_insertion(c: &mut Criterion) {
@@ -22,11 +23,12 @@ fn bench_wal_insertion(c: &mut Criterion) {
     let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
     let segment_config = CollectionConfig {
         num_features: 128,
-        // Enable WAL for this benchmark
+        // Enable WAL for this benchmark with write grouping
         wal_file_size: 1024 * 1024, // 1MB WAL file size
+        wal_write_group_size: 970,  // Group size for batching (tuned for this benchmark)
         ..CollectionConfig::default()
     };
-    // Create the collection outside of the benchmark
+
     // Remove everything under base_directory
     std::fs::remove_dir_all(&base_directory).unwrap();
 
@@ -57,88 +59,59 @@ fn bench_wal_insertion(c: &mut Criterion) {
         }
     });
 
-    // Start background thread to sync WAL outside of benchmark
-    let sync_running = Arc::new(AtomicBool::new(true));
-    let sync_running_clone = sync_running.clone();
-    let collection_clone_for_sync = collection.clone();
-    let sync_thread = thread::spawn(move || {
-        while sync_running_clone.load(Ordering::Relaxed) {
-            // Sync WAL in a blocking context
-            if let Err(e) = collection_clone_for_sync.sync_wal() {
-                eprintln!("Error syncing WAL: {e}");
-            }
-            // Small delay to prevent busy looping
-            thread::sleep(Duration::from_micros(100));
-        }
-    });
-
     let num_vectors = 1000;
     let num_features = segment_config.num_features;
-    let vectors = (0..num_vectors)
-        .map(|_| generate_random_vector(num_features))
-        .collect::<Vec<_>>();
-    let user_ids = vec![0];
+    let vectors: Vec<Arc<[f32]>> = (0..num_vectors)
+        .map(|_| Arc::from(generate_random_vector(num_features).as_slice()))
+        .collect();
+    let vectors = Arc::new(vectors); // Share the entire collection
+    let user_ids: Arc<[u128]> = Arc::from(vec![0].as_slice());
+
+    // Number of concurrent tasks
+    const NUM_TASKS: usize = 1000;
+
+    // Use async runtime for proper concurrent context
+    let rt = tokio::runtime::Runtime::new().unwrap();
 
     group.bench_with_input(
         BenchmarkId::new("WalInsertion", 1000),
         &1000,
         |bencher, _| {
             bencher.iter(|| {
-                // Create a vector to store thread handles
-                let mut handles = vec![];
+                rt.block_on(async {
+                    let mut join_set = JoinSet::new();
 
-                // Number of threads and documents per thread
-                const NUM_THREADS: usize = 40;
-                const DOCS_PER_THREAD: usize = 25;
+                    // Spawn concurrent async tasks instead of threads
+                    for task_id in 0..NUM_TASKS {
+                        let collection_clone = collection.clone();
+                        let user_ids_clone = user_ids.clone();
+                        let vectors_clone = vectors.clone(); // Just cloning the Arc pointer
 
-                // Clone the collection for each thread
-                let collection_clones: Vec<_> =
-                    (0..NUM_THREADS).map(|_| collection.clone()).collect();
+                        join_set.spawn(async move {
+                            let doc_id = task_id as u128;
+                            let data = vectors_clone[task_id % vectors_clone.len()].clone();
+                            let user_ids_ref = user_ids_clone.clone();
+                            let doc_ids: Arc<[u128]> = Arc::from([doc_id]);
 
-                // Spawn 10 threads, each handling 100 document IDs
-                (0..NUM_THREADS).for_each(|thread_idx| {
-                    let collection_clone = collection_clones[thread_idx].clone();
-                    let user_ids_clone = user_ids.clone();
-                    let vectors_clone = vectors.clone();
-
-                    let handle = std::thread::spawn(move || {
-                        // Create a Tokio runtime for each thread
-                        let rt = tokio::runtime::Runtime::new().unwrap();
-                        let start_doc_id = thread_idx * DOCS_PER_THREAD;
-                        let end_doc_id = start_doc_id + DOCS_PER_THREAD;
-
-                        (start_doc_id..end_doc_id).for_each(|doc_id| {
-                            let data: Arc<[f32]> = Arc::from(vectors_clone[doc_id].as_slice());
-                            let user_ids: Arc<[u128]> = Arc::from(user_ids_clone.as_slice());
-                            let doc_ids: Arc<[u128]> = Arc::from([doc_id as u128]);
-                            // Use write_to_wal instead of insert_for_users
-                            // This is the only operation being measured in the benchmark
-                            rt.block_on(collection_clone.write_to_wal(
-                                doc_ids,
-                                user_ids,
-                                data,
-                                WalOpType::Insert,
-                            ))
-                            .unwrap();
+                            collection_clone
+                                .write_to_wal(doc_ids, user_ids_ref, data, WalOpType::Insert)
+                                .await
+                                .unwrap()
                         });
-                    });
+                    }
 
-                    handles.push(handle);
+                    // Wait for all tasks to complete concurrently
+                    while let Some(result) = join_set.join_next().await {
+                        result.unwrap(); // Ensure no task panicked
+                    }
                 });
-
-                // Wait for all threads to complete
-                for handle in handles {
-                    handle.join().unwrap();
-                }
             });
         },
     );
 
     // Stop the background threads
     running.store(false, Ordering::Relaxed);
-    sync_running.store(false, Ordering::Relaxed);
     background_thread.join().unwrap();
-    sync_thread.join().unwrap();
 
     group.finish();
 }

--- a/rs/config/src/collection.rs
+++ b/rs/config/src/collection.rs
@@ -119,6 +119,12 @@ pub struct CollectionConfig {
     #[serde(default = "default_wal_file_size")]
     pub wal_file_size: u64,
 
+    /// Maximum follower entries per WAL write group before closing for batch processing.
+    /// Small values = lower latency, higher sync overhead. Large values = higher throughput, higher latency.
+    /// Default: 1
+    #[serde(default = "default_wal_write_group_size")]
+    pub wal_write_group_size: usize,
+
     /// The maximum number of pending operations before flushing.
     /// Default: 0 (not using max pending ops)
     #[serde(default = "default_max_pending_ops")]
@@ -145,6 +151,10 @@ pub struct CollectionConfig {
 
 fn default_wal_file_size() -> u64 {
     0
+}
+
+fn default_wal_write_group_size() -> usize {
+    1
 }
 
 fn default_max_pending_ops() -> u64 {
@@ -189,6 +199,7 @@ impl Default for CollectionConfig {
             posting_list_kmeans_unbalanced_penalty: 0.0,
             reindex: true,
             wal_file_size: 0,
+            wal_write_group_size: default_wal_write_group_size(),
             max_pending_ops: 0,
             max_time_to_flush_ms: 0,
             max_number_of_segments: 10,
@@ -224,6 +235,7 @@ impl CollectionConfig {
             reindex: true,
             quantization_type: QuantizerType::NoQuantizer,
             wal_file_size: 1024 * 1024 * 1024,
+            wal_write_group_size: default_wal_write_group_size(),
             max_pending_ops: 10000,
             max_time_to_flush_ms: 10000,
             max_number_of_segments: 10,

--- a/rs/config/src/collection.rs
+++ b/rs/config/src/collection.rs
@@ -121,7 +121,7 @@ pub struct CollectionConfig {
 
     /// Maximum follower entries per WAL write group before closing for batch processing.
     /// Small values = lower latency, higher sync overhead. Large values = higher throughput, higher latency.
-    /// Default: 1
+    /// Default: 940
     #[serde(default = "default_wal_write_group_size")]
     pub wal_write_group_size: usize,
 
@@ -154,7 +154,7 @@ fn default_wal_file_size() -> u64 {
 }
 
 fn default_wal_write_group_size() -> usize {
-    1
+    940
 }
 
 fn default_max_pending_ops() -> u64 {

--- a/rs/index/src/collection/core.rs
+++ b/rs/index/src/collection/core.rs
@@ -1132,7 +1132,7 @@ mod tests {
     use rand::Rng;
     use tempdir::TempDir;
 
-    use crate::collection::collection::Collection;
+    use crate::collection::core::Collection;
     use crate::collection::reader::CollectionReader;
     use crate::collection::snapshot::Snapshot;
     use crate::optimizers::noop::NoopOptimizer;

--- a/rs/index/src/collection/mod.rs
+++ b/rs/index/src/collection/mod.rs
@@ -147,9 +147,9 @@ impl BoxedCollection {
 
     pub async fn write_to_wal(
         &self,
-        doc_ids: &[u128],
-        user_ids: &[u128],
-        data: &[f32],
+        doc_ids: Arc<[u128]>,
+        user_ids: Arc<[u128]>,
+        data: Arc<[f32]>,
         wal_op_type: WalOpType,
     ) -> Result<u64> {
         match self {

--- a/rs/index/src/collection/mod.rs
+++ b/rs/index/src/collection/mod.rs
@@ -1,12 +1,12 @@
-pub mod collection;
+pub mod core;
 pub mod reader;
 pub mod snapshot;
 
+use core::{Collection, SegmentInfoAndVersion};
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Result;
-use collection::{Collection, SegmentInfoAndVersion};
 use proto::muopdb::DocumentAttribute;
 use quantization::noq::noq::NoQuantizer;
 use quantization::pq::pq::ProductQuantizer;

--- a/rs/index/src/collection/reader.rs
+++ b/rs/index/src/collection/reader.rs
@@ -6,7 +6,7 @@ use parking_lot::RwLock;
 use quantization::quantization::Quantizer;
 use utils::io::get_latest_version;
 
-use super::collection::Collection;
+use super::core::Collection;
 use super::TableOfContent;
 use crate::multi_spann::reader::MultiSpannReader;
 use crate::segment::immutable_segment::ImmutableSegment;

--- a/rs/index/src/collection/snapshot.rs
+++ b/rs/index/src/collection/snapshot.rs
@@ -4,7 +4,7 @@ use quantization::noq::noq::NoQuantizerL2;
 use quantization::pq::pq::ProductQuantizerL2;
 use quantization::quantization::Quantizer;
 
-use super::collection::Collection;
+use super::core::Collection;
 use crate::segment::BoxedImmutableSegment;
 use crate::utils::SearchResult;
 

--- a/rs/index/src/ivf/builder.rs
+++ b/rs/index/src/ivf/builder.rs
@@ -806,7 +806,7 @@ mod tests {
 
     #[test]
     fn test_build_posting_lists() {
-        env_logger::init();
+        env_logger::try_init().ok();
 
         let temp_dir = tempdir::TempDir::new("build_posting_lists_test")
             .expect("Failed to create temporary directory");

--- a/rs/index/src/optimizers/engine.rs
+++ b/rs/index/src/optimizers/engine.rs
@@ -6,7 +6,7 @@ use quantization::quantization::Quantizer;
 use super::merge::MergeOptimizer;
 use super::noop::NoopOptimizer;
 use super::vacuum::VacuumOptimizer;
-use crate::collection::collection::Collection;
+use crate::collection::core::Collection;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum OptimizingType {

--- a/rs/index/src/optimizers/merge.rs
+++ b/rs/index/src/optimizers/merge.rs
@@ -63,7 +63,7 @@ mod tests {
     use config::collection::CollectionConfig;
 
     use super::*;
-    use crate::collection::collection::Collection;
+    use crate::collection::core::Collection;
     use crate::collection::reader::CollectionReader;
     use crate::segment::Segment;
 

--- a/rs/index/src/optimizers/vacuum.rs
+++ b/rs/index/src/optimizers/vacuum.rs
@@ -60,7 +60,7 @@ mod tests {
     use config::collection::CollectionConfig;
 
     use super::*;
-    use crate::collection::collection::Collection;
+    use crate::collection::core::Collection;
     use crate::collection::reader::CollectionReader;
     use crate::segment::Segment;
 

--- a/rs/index/src/terms/builder.rs
+++ b/rs/index/src/terms/builder.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::{anyhow, Result};
-use log::debug;
 use utils::on_disk_ordered_map::builder::OnDiskOrderedMapBuilder;
 
 use super::scratch::Scratch;
@@ -35,7 +34,7 @@ impl TermBuilder {
         }
         #[cfg(debug_assertions)]
         {
-            debug!("Adding doc: {}, term: {}", doc_id, key);
+            log::debug!("Adding doc: {}, term: {}", doc_id, key);
         }
 
         let term_id = self.persist_and_get_term_id(key);

--- a/rs/index_server/src/collection_catalog.rs
+++ b/rs/index_server/src/collection_catalog.rs
@@ -41,7 +41,7 @@ mod tests {
     use std::sync::Arc;
 
     use config::collection::CollectionConfig;
-    use index::collection::collection::Collection;
+    use index::collection::core::Collection;
     use metrics::INTERNAL_METRICS;
     use quantization::noq::noq::NoQuantizer;
     use tempdir::TempDir;

--- a/rs/index_server/src/collection_manager.rs
+++ b/rs/index_server/src/collection_manager.rs
@@ -252,30 +252,6 @@ impl CollectionManager {
         Ok(flushed_ops)
     }
 
-    pub async fn sync_wal(&self, worker_id: u32) -> Result<u64> {
-        let mut synced_entries = 0;
-        let collections = self
-            .collection_catalog
-            .get_all_collection_names_sorted()
-            .await;
-
-        for collection_name in collections {
-            // Use a simple hash-based distribution for sync_wal workers
-            if self.get_worker_id(&collection_name, self.num_flush_workers) == worker_id {
-                let collection = self
-                    .collection_catalog
-                    .get_collection(&collection_name)
-                    .await
-                    .unwrap();
-                if collection.use_wal() {
-                    debug!("Syncing WAL for collection {}", collection_name);
-                    synced_entries += collection.sync_wal()?;
-                }
-            }
-        }
-        Ok(synced_entries)
-    }
-
     pub fn get_worker_id(&self, collection_name: &str, num_workers: u32) -> u32 {
         let mut hasher = DefaultHasher::new();
         collection_name.hash(&mut hasher);

--- a/rs/index_server/src/collection_manager.rs
+++ b/rs/index_server/src/collection_manager.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::AtomicU64;
 
 use anyhow::{Context, Result};
 use config::enums::QuantizerType;
-use index::collection::collection::Collection;
+use index::collection::core::Collection;
 use index::collection::BoxedCollection;
 use log::{debug, info, warn};
 use quantization::noq::noq::NoQuantizerL2;


### PR DESCRIPTION
Implemented WAL write groups in Tokio concurrent async context for `Collection::write_to_wal` method, replacing the background thread method. Each group holds a certain number of WAL entries with a fixed upper bound (940 by default). Timeout handling is also handled, in case there are no more `write_to_wal` tasks coming in but the group still waits. Duration till timeout for a group is 100ms. 

Improvement in throughput (performed on MacOS):
```
Benchmarking WalInsertion/WalInsertion/1000: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.0s or enable flat sampling.
WalInsertion/WalInsertion/1000
                        time:   [109.71 ms 110.19 ms 110.52 ms]
                        change: [-1.9743% -1.5160% -1.0833%] (p = 0.00 < 0.05)
                        Performance has improved.
```