### PR TITLE
refactor: couple WAL op with its data

### DIFF
--- a/rs/benchmarks/src/wal_insertion.rs
+++ b/rs/benchmarks/src/wal_insertion.rs
@@ -94,7 +94,7 @@ fn bench_wal_insertion(c: &mut Criterion) {
                             let doc_ids: Arc<[u128]> = Arc::from([doc_id]);
 
                             collection_clone
-                                .write_to_wal(doc_ids, user_ids_ref, data, WalOpType::Insert)
+                                .write_to_wal(doc_ids, user_ids_ref, WalOpType::Insert(data))
                                 .await
                                 .unwrap()
                         });

--- a/rs/index/src/collection/core.rs
+++ b/rs/index/src/collection/core.rs
@@ -142,7 +142,7 @@ impl<Q: Quantizer + Clone + Send + Sync + 'static> Collection<Q> {
 
         // Create a new segment_config with a random name
         let random_name = format!("tmp_segment_{}", rand::random::<u64>());
-        let segment_base_directory = format!("{}/{}", base_directory, random_name);
+        let segment_base_directory = format!("{base_directory}/{random_name}");
 
         let mutable_segment = RwLock::new(MutableSegment::new(
             segment_config.clone(),
@@ -150,7 +150,7 @@ impl<Q: Quantizer + Clone + Send + Sync + 'static> Collection<Q> {
         )?);
 
         let wal = if segment_config.wal_file_size > 0 {
-            let wal_directory = format!("{}/wal", base_directory);
+            let wal_directory = format!("{base_directory}/wal");
             Some(RwLock::new(Wal::open(
                 &wal_directory,
                 segment_config.wal_file_size,
@@ -194,12 +194,12 @@ impl<Q: Quantizer + Clone + Send + Sync + 'static> Collection<Q> {
         std::fs::create_dir_all(base_directory.clone())?;
 
         // Write version 0
-        let toc_path = format!("{}/version_0", base_directory);
+        let toc_path = format!("{base_directory}/version_0");
         let toc = TableOfContent::default();
         serde_json::to_writer_pretty(std::fs::File::create(toc_path)?, &toc)?;
 
         // Write the config file
-        let config_path = format!("{}/collection_config.json", base_directory);
+        let config_path = format!("{base_directory}/collection_config.json");
         serde_json::to_writer_pretty(std::fs::File::create(config_path)?, config)?;
 
         Ok(())
@@ -218,12 +218,9 @@ impl<Q: Quantizer + Clone + Send + Sync + 'static> Collection<Q> {
         versions_info.write().version_ref_counts.insert(version, 0);
 
         let all_segments = DashMap::new();
-        toc.toc
-            .iter()
-            .zip(segments.into_iter())
-            .for_each(|(name, segment)| {
-                all_segments.insert(name.clone(), segment);
-            });
+        toc.toc.iter().zip(segments).for_each(|(name, segment)| {
+            all_segments.insert(name.clone(), segment);
+        });
         let last_sequence_number = toc.sequence_number;
 
         let versions = DashMap::new();
@@ -249,19 +246,19 @@ impl<Q: Quantizer + Clone + Send + Sync + 'static> Collection<Q> {
 
         // Create a new segment_config with a random name
         let random_name = format!("tmp_segment_{}", rand::random::<u64>());
-        let random_base_directory = format!("{}/{}", base_directory, random_name);
+        let random_base_directory = format!("{base_directory}/{random_name}");
         std::fs::create_dir_all(&random_base_directory)?;
         let mutable_segment = MutableSegment::new(segment_config.clone(), random_base_directory)?;
 
         let wal = if segment_config.wal_file_size > 0 {
-            let wal_directory = format!("{}/wal", base_directory);
+            let wal_directory = format!("{base_directory}/wal");
             let wal = Wal::open(
                 &wal_directory,
                 segment_config.wal_file_size,
-                last_sequence_number as i64,
+                last_sequence_number,
             )?;
             let iterators = wal.get_iterators();
-            let mut seq_no = (last_sequence_number + 1) as i64;
+            let mut seq_no = last_sequence_number + 1;
             for mut iterator in iterators {
                 if iterator.last_seq_no() < seq_no {
                     debug!(
@@ -275,7 +272,7 @@ impl<Q: Quantizer + Clone + Send + Sync + 'static> Collection<Q> {
                 for op in iterator {
                     if let anyhow::Result::Ok(wal_entry) = op {
                         let entry_seq_no = wal_entry.seq_no;
-                        debug!("Processing op with seq_no: {}", entry_seq_no);
+                        debug!("Processing op with seq_no: {entry_seq_no}");
                         let wal_entry = wal_entry.decode(segment_config.num_features);
                         match wal_entry.op_type {
                             WalOpType::Insert(data) => {
@@ -403,14 +400,14 @@ impl<Q: Quantizer + Clone + Send + Sync + 'static> Collection<Q> {
             {
                 debug!(
                     "Flushing because of max pending ops: {}",
-                    current_seq_no as i64 - flushed_seq_no as i64
+                    current_seq_no as i64 - flushed_seq_no
                 );
                 return true;
             }
         }
 
         if self.segment_config.max_time_to_flush_ms > 0 {
-            let last_flush_time = self.last_flush_time.lock().unwrap().clone();
+            let last_flush_time = *self.last_flush_time.lock().unwrap();
             let current_time = std::time::Instant::now();
             if current_time.duration_since(last_flush_time)
                 >= std::time::Duration::from_millis(self.segment_config.max_time_to_flush_ms)
@@ -442,6 +439,7 @@ impl<Q: Quantizer + Clone + Send + Sync + 'static> Collection<Q> {
             };
 
             // A closure to append to WAL and send op to channel
+            #[allow(clippy::await_holding_lock)]
             let append_wal = async |wal: &RwLock<Wal>,
                                     doc_ids: Arc<[u128]>,
                                     user_ids: Arc<[u128]>,
@@ -616,7 +614,7 @@ impl<Q: Quantizer + Clone + Send + Sync + 'static> Collection<Q> {
     pub async fn process_one_op(&self) -> Result<usize> {
         if let std::result::Result::Ok(op) = self.receiver.borrow_mut().try_recv() {
             match op.op_type {
-                WalOpType::Insert(_) => {
+                WalOpType::Insert(()) => {
                     debug!("Processing insert operation with seq_no {}", op.seq_no);
                     let doc_ids = op.doc_ids();
                     let user_ids = op.user_ids();
@@ -785,9 +783,7 @@ impl<Q: Quantizer + Clone + Send + Sync + 'static> Collection<Q> {
                 *self.last_flush_time.lock().unwrap() = Instant::now();
                 Ok(name_for_new_segment)
             }
-            Err(_) => {
-                return Err(anyhow::anyhow!("Another thread is already flushing"));
-            }
+            Err(_) => Err(anyhow::anyhow!("Another thread is already flushing")),
         }
     }
 
@@ -996,12 +992,12 @@ impl<Q: Quantizer + Clone + Send + Sync + 'static> Collection<Q> {
     }
 
     pub fn get_ref_count(&self, version_number: u64) -> usize {
-        self.versions_info
+        *self
+            .versions_info
             .read()
             .version_ref_counts
             .get(&version_number)
             .unwrap_or(&0)
-            .clone()
     }
 
     /// Release the ref count for the version once the snapshot is no longer needed.
@@ -1096,8 +1092,10 @@ impl<Q: Quantizer + Clone + Send + Sync + 'static> Collection<Q> {
         // Create and copy content of the pending segment to the new segment
         std::fs::create_dir_all(new_segment_path.clone())?;
 
-        let mut options = CopyOptions::default();
-        options.content_only = true;
+        let options = CopyOptions {
+            content_only: true,
+            ..CopyOptions::default()
+        };
         fs_extra::dir::copy(
             pending_segment_path.clone(),
             new_segment_path.clone(),
@@ -1662,7 +1660,7 @@ mod tests {
         let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
         let segment_config = CollectionConfig::default_test_config();
         // write the collection config
-        let collection_config_path = format!("{}/collection_config.json", base_directory);
+        let collection_config_path = format!("{base_directory}/collection_config.json");
         serde_json::to_writer_pretty(
             std::fs::File::create(collection_config_path)?,
             &segment_config,
@@ -1785,7 +1783,7 @@ mod tests {
                 assert!(immutable_segment.read().get_point_id(0, 5).is_none());
             }
             _ => {
-                assert!(false);
+                panic!("Expected FinalizedSegment");
             }
         }
         let toc = collection.get_current_toc();
@@ -1866,7 +1864,7 @@ mod tests {
                     assert!(immutable_segment.read().get_point_id(0, 2).is_some());
                 }
                 _ => {
-                    assert!(false);
+                    panic!("Expected FinalizedSegment");
                 }
             }
             let toc = collection.get_current_toc();
@@ -1937,7 +1935,7 @@ mod tests {
                     assert!(immutable_segment.read().get_point_id(0, 3).is_none());
                 }
                 _ => {
-                    assert!(false);
+                    panic!("Expected FinalizedSegment");
                 }
             }
 
@@ -1952,7 +1950,7 @@ mod tests {
                     assert!(immutable_segment.read().is_invalidated(0, 2)?);
                 }
                 _ => {
-                    assert!(false);
+                    panic!("Expected FinalizedSegment");
                 }
             }
             let toc = collection.get_current_toc();
@@ -2050,7 +2048,7 @@ mod tests {
                     .is_valid_doc_id(0, 4));
             }
             _ => {
-                assert!(false);
+                panic!("Expected FinalizedSegment");
             }
         }
     }
@@ -2120,8 +2118,10 @@ mod tests {
         let collection_name = "test_collection_metrics";
         let temp_dir = TempDir::new(collection_name).unwrap();
         let base_directory: String = temp_dir.path().to_str().unwrap().to_string();
-        let mut segment_config = CollectionConfig::default();
-        segment_config.num_features = 16; // Set a specific feature size for precise calculations
+        let segment_config = CollectionConfig {
+            num_features: 16, // Set a specific feature size for precise calculations
+            ..CollectionConfig::default()
+        };
         let collection = Arc::new(
             Collection::<NoQuantizerL2>::new(
                 collection_name.to_string(),

--- a/rs/index/src/wal/entry.rs
+++ b/rs/index/src/wal/entry.rs
@@ -8,16 +8,17 @@ pub struct WalEntry {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum WalOpType {
-    Insert,
+pub enum WalOpType<T> {
+    /// Insert operation with associated data
+    Insert(T),
+    /// Delete operation
     Delete,
 }
 
 pub struct WalEntryDecoded<'a> {
     pub doc_ids: &'a [u128],
     pub user_ids: &'a [u128],
-    pub data: &'a [f32],
-    pub op_type: WalOpType,
+    pub op_type: WalOpType<&'a [f32]>,
 }
 
 impl WalEntry {
@@ -42,7 +43,7 @@ impl WalEntry {
                 num_features * num_docs,
                 "num_vectors mismatch while decoding WalEntry data"
             );
-            WalOpType::Insert
+            WalOpType::Insert(data)
         } else {
             assert_eq!(data.len(), 0, "WalEntry data should be empty for delete op");
             WalOpType::Delete
@@ -50,7 +51,6 @@ impl WalEntry {
         WalEntryDecoded {
             doc_ids,
             user_ids,
-            data,
             op_type,
         }
     }

--- a/rs/index_server/src/index_server.rs
+++ b/rs/index_server/src/index_server.rs
@@ -275,8 +275,7 @@ impl IndexServer for IndexServerImpl {
                     .write_to_wal(
                         doc_ids.clone(),
                         user_ids.clone(),
-                        vectors.clone(),
-                        WalOpType::Insert,
+                        WalOpType::Insert(vectors.clone()),
                     )
                     .await
                     .unwrap_or(0);
@@ -348,12 +347,7 @@ impl IndexServer for IndexServerImpl {
                 let user_ids: Arc<[u128]> = Arc::from(user_ids);
 
                 let seq_no = collection
-                    .write_to_wal(
-                        ids.clone(),
-                        user_ids.clone(),
-                        Arc::from([]),
-                        WalOpType::Delete,
-                    )
+                    .write_to_wal(ids.clone(), user_ids.clone(), WalOpType::Delete)
                     .await
                     .unwrap_or(0);
                 let num_docs_removed = ids.len() as u32;
@@ -469,8 +463,7 @@ impl IndexServer for IndexServerImpl {
                     .write_to_wal(
                         doc_ids.clone(),
                         user_ids.clone(),
-                        vectors.clone(),
-                        WalOpType::Insert,
+                        WalOpType::Insert(vectors.clone()),
                     )
                     .await
                     .unwrap_or(0);


### PR DESCRIPTION
Modified `WalOpType` enum to contain the data for `WalOpType::Insert` variant:
```rust
pub enum WalOpType<T> {
    /// Insert operation with associated data
    Insert(T),
    /// Delete operation
    Delete,
}
```
This prevents the need to assert empty data when sent along with `WalOpType::Delete` variant every time we want to call `WalFile::append`, preventing invalid state.