### PR TITLE
perf: reduce default follower timeout to 10ms

### DIFF
--- a/rs/index/src/collection/core.rs
+++ b/rs/index/src/collection/core.rs
@@ -545,7 +545,7 @@ impl<Q: Quantizer + Clone + Send + Sync + 'static> Collection<Q> {
                         debug!("[WAL follower] Received seq_no {follower_seq_no} from leader");
                         Ok(follower_seq_no)
                     }
-                    _ = tokio::time::sleep(Duration::from_millis(100)) => {
+                    _ = tokio::time::sleep(Duration::from_millis(10)) => {
                         debug!("[WAL follower] Timeout reached, checking if I should become leader");
 
                         // Timeout: check if I'm the first entry and should become leader


### PR DESCRIPTION
```
➜  muopdb git:(master) cargo bench --bench wal_insertion
   Compiling index v0.1.0 (/Users/hieu/code/muopdb/rs/index)   Compiling benchmarks v0.1.0 (/Users/hieu/code/muopdb/rs/benchmarks)
    Finished `bench` profile [optimized] target(s) in 4.44s
     Running src/wal_insertion.rs (target/release/deps/wal_insertion-ad71d50f618f8099)
WalInsertion/WalInsertion/1000
                        time:   [31.609 ms 32.138 ms 32.787 ms]
                        change: [-72.316% -71.793% -71.322%] (p = 0.00 < 0.05)
                        Performance has improved.
```

benchmark goes from 113ms to 32ms.