### PR TITLE
feat: multi-user term builder and writer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-  "rs/aggregator", 
+  "rs/aggregator",
   "rs/benchmarks",
   "rs/cli",
   "rs/compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ resolver = "2"
 [profile.release]
 strip = true
 
+[workspace.lints.clippy]
+uninlined_format_args = "allow"
+
 [workspace.dependencies]
 aggregator = { path = './rs/aggregator' }
 anyhow = "1.0.90"

--- a/rs/aggregator/Cargo.toml
+++ b/rs/aggregator/Cargo.toml
@@ -3,6 +3,9 @@ name = "aggregator"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 proto.workspace = true
 tonic.workspace = true

--- a/rs/benchmarks/src/deletion_and_vacuum.rs
+++ b/rs/benchmarks/src/deletion_and_vacuum.rs
@@ -51,12 +51,12 @@ fn bench_deletion_vacuum(c: &mut Criterion) {
                         CollectionReader::new(collection_name.to_string(), base_directory.clone());
                     let collection = reader.read::<NoQuantizerL2>().unwrap();
                     let mut doc_id = 0;
-                    for vector in vectors.iter() {
+                    vectors.iter().for_each(|vector| {
                         collection
                             .insert_for_users(&user_ids, doc_id, vector, 0, None)
                             .unwrap();
                         doc_id += 1;
-                    }
+                    });
                     let segment_name = collection.flush().unwrap();
                     (collection, vec![segment_name])
                 },

--- a/rs/benchmarks/src/insertion.rs
+++ b/rs/benchmarks/src/insertion.rs
@@ -46,12 +46,12 @@ fn bench_insertion(c: &mut Criterion) {
                 },
                 |collection| {
                     let mut doc_id = 0;
-                    for vector in vectors.iter() {
+                    vectors.iter().for_each(|vector| {
                         collection
                             .insert_for_users(&user_ids, doc_id, vector, 0, None)
                             .unwrap();
                         doc_id += 1;
-                    }
+                    });
                     collection.flush().unwrap();
                 },
             );

--- a/rs/benchmarks/src/vacuum.rs
+++ b/rs/benchmarks/src/vacuum.rs
@@ -48,12 +48,12 @@ fn vacuum(c: &mut Criterion) {
                     CollectionReader::new(collection_name.to_string(), base_directory.clone());
                 let collection = reader.read::<NoQuantizerL2>().unwrap();
                 let mut doc_id = 0;
-                for vector in vectors.iter() {
+                vectors.iter().for_each(|vector| {
                     collection
                         .insert_for_users(&user_ids, doc_id, vector, 0, None)
                         .unwrap();
                     doc_id += 1;
-                }
+                });
                 let segment_name = collection.flush().unwrap();
                 let pending_segment = collection.init_optimizing(&vec![segment_name]).unwrap();
                 for doc_id in doc_ids_to_delete.iter() {

--- a/rs/cli/Cargo.toml
+++ b/rs/cli/Cargo.toml
@@ -3,6 +3,9 @@ name = "cli"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "client"
 path = "src/main.rs"

--- a/rs/cli/src/index_viewer.rs
+++ b/rs/cli/src/index_viewer.rs
@@ -47,10 +47,11 @@ pub fn main() {
         println!("======= Layer: {} =======", layer);
         let predicate = |l: u8, node_id: u32| -> bool {
             if l == 0 {
-                return node_id < points_per_layer_0 as u32;
+                node_id < points_per_layer_0 as u32
+            } else {
+                node_id < points_per_layer as u32
             }
-            return node_id < points_per_layer as u32;
         };
-        hnsw.print_graph(layer as u8, predicate);
+        hnsw.print_graph(layer, predicate);
     }
 }

--- a/rs/compression/src/elias_fano/ef.rs
+++ b/rs/compression/src/elias_fano/ef.rs
@@ -391,9 +391,9 @@ mod tests {
         let mut ef = EliasFano::<u32>::new_encoder(upper_bound, values.len());
         assert!(ef.encode_batch(&values).is_ok());
 
-        for i in 0..values.len() {
+        for (i, value) in values.iter().enumerate() {
             let decoded_value = ef.get(i).expect("Failed to decode value");
-            assert_eq!(values[i], decoded_value);
+            assert_eq!(*value, decoded_value);
         }
     }
 
@@ -404,9 +404,9 @@ mod tests {
         let mut ef = EliasFano::<u128>::new_encoder(upper_bound, values.len());
         assert!(ef.encode_batch(&values).is_ok());
 
-        for i in 0..values.len() {
+        for (i, value) in values.iter().enumerate() {
             let decoded_value = ef.get(i).expect("Failed to decode value");
-            assert_eq!(values[i], decoded_value);
+            assert_eq!(*value, decoded_value);
         }
     }
 
@@ -424,10 +424,10 @@ mod tests {
             let mut ef = EliasFano::new_encoder(upper_bound, values.len());
             assert!(ef.encode_batch(&values).is_ok());
 
-            for i in 0..values.len() {
+            (0..values.len()).for_each(|i| {
                 let decoded_value = ef.get(i).expect("Failed to decode value");
                 assert_eq!(values[i], decoded_value);
-            }
+            });
         }
 
         // Test random access on a larger set
@@ -524,10 +524,8 @@ mod tests {
 
             let decoder = EliasFanoDecoder::new_decoder(&byte_slice)
                 .expect("Failed to create posting list decoder");
-            let mut i = 0;
-            for idx in decoder.get_iterator(&byte_slice) {
+            for (i, idx) in decoder.get_iterator(&byte_slice).enumerate() {
                 assert_eq!(values[i], idx);
-                i += 1;
             }
 
             let _ = remove_dir_all(&file_path);
@@ -556,11 +554,9 @@ mod tests {
 
         let decoder =
             EliasFanoDecoder::<u32>::new_decoder(&byte_slice).expect("Failed to create decoder");
-        let mut iterator = decoder.get_iterator(&byte_slice);
-        let mut i = 0;
-        while let Some(decoded_value) = iterator.next() {
+        let iterator = decoder.get_iterator(&byte_slice);
+        for (i, decoded_value) in iterator.enumerate() {
             assert_eq!(values[i], decoded_value);
-            i += 1;
         }
 
         let _ = remove_dir_all(&file_path);
@@ -588,11 +584,9 @@ mod tests {
 
         let decoder =
             EliasFanoDecoder::<u128>::new_decoder(&byte_slice).expect("Failed to create decoder");
-        let mut iterator = decoder.get_iterator(&byte_slice);
-        let mut i = 0;
-        while let Some(decoded_value) = iterator.next() {
+        let iterator = decoder.get_iterator(&byte_slice);
+        for (i, decoded_value) in iterator.enumerate() {
             assert_eq!(values[i], decoded_value);
-            i += 1;
         }
 
         let _ = remove_dir_all(&file_path);

--- a/rs/config/src/attribute_schema.rs
+++ b/rs/config/src/attribute_schema.rs
@@ -25,18 +25,15 @@ impl From<muopdb::AttributeSchema> for AttributeSchema {
     fn from(value: muopdb::AttributeSchema) -> Self {
         let mut fields = HashMap::<String, AttributeType>::new();
         value.attributes.into_iter().for_each(|attribute| {
-            let attribute_type;
-            match attribute.r#type() {
-                muopdb::AttributeType::Int => attribute_type = AttributeType::Integer,
-                muopdb::AttributeType::Float => attribute_type = AttributeType::Float,
-                muopdb::AttributeType::Bool => attribute_type = AttributeType::Boolean,
-                muopdb::AttributeType::Keyword => attribute_type = AttributeType::Keyword,
-                muopdb::AttributeType::Text => attribute_type = AttributeType::Text,
-                muopdb::AttributeType::VectorInt => attribute_type = AttributeType::VectorInt,
-                muopdb::AttributeType::VectorKeyword => {
-                    attribute_type = AttributeType::VectorKeyword
-                }
-            }
+            let attribute_type = match attribute.r#type() {
+                muopdb::AttributeType::Int => AttributeType::Integer,
+                muopdb::AttributeType::Float => AttributeType::Float,
+                muopdb::AttributeType::Bool => AttributeType::Boolean,
+                muopdb::AttributeType::Keyword => AttributeType::Keyword,
+                muopdb::AttributeType::Text => AttributeType::Text,
+                muopdb::AttributeType::VectorInt => AttributeType::VectorInt,
+                muopdb::AttributeType::VectorKeyword => AttributeType::VectorKeyword,
+            };
             fields.insert(attribute.name.clone(), attribute_type);
         });
         Self::new(fields)
@@ -55,35 +52,36 @@ mod tests {
 
     #[test]
     fn test_from_trait_conversion() {
-        let mut proto_attributes = Vec::new();
-        proto_attributes.push(muopdb::AttributeField {
-            name: "i32_field".to_string(),
-            r#type: muopdb::AttributeType::Int as i32,
-        });
-        proto_attributes.push(muopdb::AttributeField {
-            name: String::from("text_field"),
-            r#type: muopdb::AttributeType::Text as i32,
-        });
-        proto_attributes.push(muopdb::AttributeField {
-            name: String::from("float_field"),
-            r#type: muopdb::AttributeType::Float as i32,
-        });
-        proto_attributes.push(muopdb::AttributeField {
-            name: String::from("bool_field"),
-            r#type: muopdb::AttributeType::Bool as i32,
-        });
-        proto_attributes.push(muopdb::AttributeField {
-            name: String::from("vector_int_field"),
-            r#type: muopdb::AttributeType::VectorInt as i32,
-        });
-        proto_attributes.push(muopdb::AttributeField {
-            name: String::from("vector_keyword_field"),
-            r#type: muopdb::AttributeType::VectorKeyword as i32,
-        });
-        proto_attributes.push(muopdb::AttributeField {
-            name: String::from("keyword_field"),
-            r#type: muopdb::AttributeType::Keyword as i32,
-        });
+        let proto_attributes = vec![
+            muopdb::AttributeField {
+                name: String::from("i32_field"),
+                r#type: muopdb::AttributeType::Int as i32,
+            },
+            muopdb::AttributeField {
+                name: String::from("text_field"),
+                r#type: muopdb::AttributeType::Text as i32,
+            },
+            muopdb::AttributeField {
+                name: String::from("float_field"),
+                r#type: muopdb::AttributeType::Float as i32,
+            },
+            muopdb::AttributeField {
+                name: String::from("bool_field"),
+                r#type: muopdb::AttributeType::Bool as i32,
+            },
+            muopdb::AttributeField {
+                name: String::from("vector_int_field"),
+                r#type: muopdb::AttributeType::VectorInt as i32,
+            },
+            muopdb::AttributeField {
+                name: String::from("vector_keyword_field"),
+                r#type: muopdb::AttributeType::VectorKeyword as i32,
+            },
+            muopdb::AttributeField {
+                name: String::from("keyword_field"),
+                r#type: muopdb::AttributeType::Keyword as i32,
+            },
+        ];
 
         let expected_schema_len = proto_attributes.len();
         let proto_schema = muopdb::AttributeSchema {

--- a/rs/demo/Cargo.toml
+++ b/rs/demo/Cargo.toml
@@ -3,6 +3,9 @@ name = "demo"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 tonic.workspace = true
 hdf5.workspace = true

--- a/rs/demo/src/main.rs
+++ b/rs/demo/src/main.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
 
         let mut vectors = Vec::with_capacity(batch.len() * 768);
         for row in batch.rows() {
-            vectors.extend(row.iter().map(|&v| v as f32));
+            vectors.extend(row.iter().copied());
         }
 
         // Generate IDs

--- a/rs/index/Cargo.toml
+++ b/rs/index/Cargo.toml
@@ -3,6 +3,9 @@ name = "index"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1.0.90"
 bit-vec.workspace = true

--- a/rs/index/src/collection/snapshot.rs
+++ b/rs/index/src/collection/snapshot.rs
@@ -45,15 +45,12 @@ impl<Q: Quantizer + Clone + Send + Sync + 'static> Snapshot<Q> {
     {
         let mut results = SearchResult::new();
         for user_id in user_ids {
-            match snapshot
+            if let Some(id_results) = snapshot
                 .search_for_user(*user_id, query.clone(), k, ef_construction, record_pages)
                 .await
             {
-                Some(id_results) => {
-                    results.id_with_scores.extend(id_results.id_with_scores);
-                    results.stats.merge(&id_results.stats);
-                }
-                None => {}
+                results.id_with_scores.extend(id_results.id_with_scores);
+                results.stats.merge(&id_results.stats);
             }
         }
 
@@ -140,7 +137,7 @@ impl SnapshotWithQuantizer {
                 Snapshot::<NoQuantizerL2>::search_for_users(
                     snapshot,
                     user_ids,
-                    query.clone(),
+                    query,
                     k,
                     ef_construction,
                     record_pages,
@@ -151,7 +148,7 @@ impl SnapshotWithQuantizer {
                 Snapshot::<ProductQuantizerL2>::search_for_users(
                     snapshot,
                     user_ids,
-                    query.clone(),
+                    query,
                     k,
                     ef_construction,
                     record_pages,

--- a/rs/index/src/hnsw/reader.rs
+++ b/rs/index/src/hnsw/reader.rs
@@ -52,19 +52,17 @@ impl HnswReader {
             )?,
         ));
         let edges_padding = (4 - (offset % 4)) % 4;
-        let edges_offset = offset + edges_padding as usize;
+        let edges_offset = offset + edges_padding;
         let points_offset = edges_offset + header.edges_len as usize;
 
         let edge_offsets_padding = (8 - ((points_offset + header.points_len as usize) % 8)) % 8;
-        let edge_offsets_offset =
-            points_offset + header.points_len as usize + edge_offsets_padding as usize;
+        let edge_offsets_offset = points_offset + header.points_len as usize + edge_offsets_padding;
         let level_offsets_offset = edge_offsets_offset + header.edge_offsets_len as usize;
 
         let doc_id_mapping_padding =
             (16 - ((level_offsets_offset + header.level_offsets_len as usize) % 16)) % 16;
-        let doc_id_mapping_offset = level_offsets_offset
-            + header.level_offsets_len as usize
-            + doc_id_mapping_padding as usize;
+        let doc_id_mapping_offset =
+            level_offsets_offset + header.level_offsets_len as usize + doc_id_mapping_padding;
 
         Ok(Hnsw::new(
             backing_file,
@@ -161,8 +159,8 @@ mod tests {
         // Train a product quantizer
         let mut pq_builder = ProductQuantizerBuilder::new(pq_config, pq_builder_config);
 
-        for i in 0..1000 {
-            pq_builder.add(datapoints[i].clone());
+        for datapoint in datapoints.iter().take(1000) {
+            pq_builder.add(datapoint.clone());
         }
         let pq = pq_builder.build(base_directory.clone()).unwrap();
         assert!(pq.write_to_directory(&pq_dir).is_ok());
@@ -173,8 +171,8 @@ mod tests {
         let mut hnsw_builder = HnswBuilder::<ProductQuantizer<L2DistanceCalculator>>::new(
             10, 128, 20, 1024, 4096, 16, pq, vector_dir,
         );
-        for i in 0..datapoints.len() {
-            hnsw_builder.insert(i as u128, &datapoints[i]).unwrap();
+        for (i, datapoint) in datapoints.iter().enumerate() {
+            hnsw_builder.insert(i as u128, datapoint).unwrap();
         }
 
         let hnsw_dir = format!("{}/hnsw", base_directory);
@@ -207,8 +205,8 @@ mod tests {
 
         let mut hnsw_builder =
             HnswBuilder::new(10, 128, 20, 1024, 4096, 128, quantizer, vector_dir);
-        for i in 0..datapoints.len() {
-            hnsw_builder.insert(i as u128, &datapoints[i]).unwrap();
+        for (i, datapoint) in datapoints.iter().enumerate() {
+            hnsw_builder.insert(i as u128, datapoint).unwrap();
         }
 
         let hnsw_dir = format!("{}/hnsw", base_directory);

--- a/rs/index/src/hnsw/utils.rs
+++ b/rs/index/src/hnsw/utils.rs
@@ -82,7 +82,7 @@ pub trait GraphTraversal<Q: Quantizer> {
 
         while !candidates.is_empty() {
             let point_and_distance = candidates.pop().unwrap();
-            let point_id = point_and_distance.point_id as u32;
+            let point_id = point_and_distance.point_id;
             let distance: f32 = -*point_and_distance.distance;
 
             let mut furthest_element_from_working_list = working_list.peek().unwrap();

--- a/rs/index/src/hnsw/writer.rs
+++ b/rs/index/src/hnsw/writer.rs
@@ -57,31 +57,31 @@ impl<Q: Quantizer> HnswWriter<Q> {
         let doc_id_mapping_path = format!("{}/doc_id_mapping", self.base_directory);
         let mut doc_id_mapping_file = File::create(doc_id_mapping_path).unwrap();
         let mut doc_id_mapping_buffer_writer = BufWriter::new(&mut doc_id_mapping_file);
-        let mut doc_id_mapping_file_len = 0 as u64;
+        let mut doc_id_mapping_file_len = 0_u64;
 
         // Edges writer
         let edges_path = format!("{}/edges", self.base_directory);
         let mut edges_file = File::create(edges_path).unwrap();
         let mut edges_buffer_writer = BufWriter::new(&mut edges_file);
-        let mut edges_file_len = 0 as u64;
+        let mut edges_file_len = 0_u64;
 
         // Points writer
         let points_path = format!("{}/points", self.base_directory);
         let mut points_file = File::create(points_path).unwrap();
         let mut points_buffer_writer = BufWriter::new(&mut points_file);
-        let mut points_file_len = 0 as u64;
+        let mut points_file_len = 0_u64;
 
         // Edge offsets writer
         let edge_offsets_path = format!("{}/edge_offsets", self.base_directory);
         let mut edge_offsets_file = File::create(edge_offsets_path).unwrap();
         let mut edge_offsets_buffer_writer = BufWriter::new(&mut edge_offsets_file);
-        let mut edge_offsets_file_len = 0 as u64;
+        let mut edge_offsets_file_len = 0_u64;
 
         // Level offsets writer
         let level_offsets_path = format!("{}/level_offsets", self.base_directory);
         let mut level_offsets_file = File::create(level_offsets_path).unwrap();
         let mut level_offsets_buffer_writer = BufWriter::new(&mut level_offsets_file);
-        let mut level_offsets_file_len = 0 as u64;
+        let mut level_offsets_file_len = 0_u64;
 
         let vectors_path = format!("{}/vector_storage", self.base_directory);
         let mut vectors_file = File::create(vectors_path).unwrap();
@@ -92,7 +92,7 @@ impl<Q: Quantizer> HnswWriter<Q> {
         let mut level_offsets = Vec::<usize>::new();
         let mut edge_offsets = Vec::<usize>::new();
 
-        let mut num_edges = 0 as usize;
+        let mut num_edges = 0_usize;
 
         // In each level, we append edges and points to file.
         // TODO(hicder): We might not need to write points for level 0...
@@ -525,8 +525,8 @@ mod tests {
         // Train a product quantizer
         let mut pq_builder = ProductQuantizerBuilder::new(pq_config, pq_builder_config);
 
-        for i in 0..1000 {
-            pq_builder.add(datapoints[i].clone());
+        for datapoint in datapoints.into_iter().take(1000) {
+            pq_builder.add(datapoint);
         }
         let pq = pq_builder.build(base_directory.clone()).unwrap();
         assert!(pq.write_to_directory(&pq_dir).is_ok());

--- a/rs/index/src/ivf/builder.rs
+++ b/rs/index/src/ivf/builder.rs
@@ -208,10 +208,9 @@ impl<D: DistanceCalculator + CalculateSquared + Send + Sync> IvfBuilder<D> {
     }
 
     /// Add a new vector to the dataset for training
-    pub fn add_vector(&mut self, doc_id: u128, data: &[f32]) -> Result<()> {
+    pub fn add_vector(&mut self, doc_id: u128, data: &[f32]) -> Result<u32> {
         self.vectors.append(data)?;
-        self.generate_id(doc_id)?;
-        Ok(())
+        self.generate_id(doc_id)
     }
 
     /// Add a new centroid

--- a/rs/index/src/ivf/files/invalidated_ids.rs
+++ b/rs/index/src/ivf/files/invalidated_ids.rs
@@ -518,13 +518,12 @@ mod tests {
         assert_eq!(invalidation2.as_ref().unwrap().doc_id, doc_id2);
 
         // Case 2: write full buffers to multiple files
-        let mut large_invalidations = Vec::new();
-        for i in 0..2048 {
-            large_invalidations.push(InvalidatedUserDocId {
+        let large_invalidations: Vec<InvalidatedUserDocId> = (0..2048)
+            .map(|i| InvalidatedUserDocId {
                 user_id: user_id1 + i as u128,
                 doc_id: doc_id1 + i as u128,
-            });
-        }
+            })
+            .collect();
         assert!(storage.invalidate_batch(&large_invalidations).is_ok());
 
         // Verify state after case 2
@@ -543,16 +542,16 @@ mod tests {
             iter.next();
         }
 
-        for i in 0..2048 {
+        for large_invalidation in large_invalidations.iter() {
             let invalidation = iter.next();
             assert!(invalidation.is_some());
             assert_eq!(
                 invalidation.as_ref().unwrap().user_id,
-                large_invalidations[i].user_id
+                large_invalidation.user_id
             );
             assert_eq!(
                 invalidation.as_ref().unwrap().doc_id,
-                large_invalidations[i].doc_id
+                large_invalidation.doc_id
             );
         }
     }

--- a/rs/index/src/multi_spann/builder.rs
+++ b/rs/index/src/multi_spann/builder.rs
@@ -44,7 +44,7 @@ impl MultiSpannBuilder {
     /// * `user_id` - The ID of the user.
     /// * `doc_id` - The ID of the document.
     /// * `data` - The data to insert.
-    pub fn insert(&self, user_id: u128, doc_id: u128, data: &[f32]) -> Result<()> {
+    pub fn insert(&self, user_id: u128, doc_id: u128, data: &[f32]) -> Result<u32> {
         let spann_builder = self.inner_builders.entry(user_id).or_insert_with(|| {
             let user_directory = format!("{}/{}", self.base_directory, user_id);
             RwLock::new(
@@ -55,9 +55,9 @@ impl MultiSpannBuilder {
                 .unwrap(),
             )
         });
-        spann_builder.write().add(doc_id, data)?;
+        let point_id = spann_builder.write().add(doc_id, data)?;
         self.doc_id_counts.fetch_add(1, Ordering::Relaxed);
-        Ok(())
+        Ok(point_id)
     }
 
     /// Invalidates a document ID for a given user.

--- a/rs/index/src/multi_spann/index.rs
+++ b/rs/index/src/multi_spann/index.rs
@@ -37,7 +37,7 @@ impl<Q: Quantizer> MultiSpannIndex<Q> {
         let user_index_infos = HashTableOwned::from_raw_bytes(&user_index_info_mmap).unwrap();
 
         // Read invalidated ids
-        let invalidated_ids_directory = format!("{}/invalidated_ids_storage", base_directory);
+        let invalidated_ids_directory = format!("{base_directory}/invalidated_ids_storage");
 
         // Initialize InvalidatedIdsStorage
         let invalidated_ids_storage = InvalidatedIdsStorage::read(&invalidated_ids_directory)?;
@@ -402,7 +402,7 @@ mod tests {
         let num_vectors = 1000;
         let num_features = 4;
 
-        let invalidated_ids_dir = format!("{}/invalidated_ids_storage", base_directory);
+        let invalidated_ids_dir = format!("{base_directory}/invalidated_ids_storage");
         assert!(fs::create_dir(&invalidated_ids_dir).is_ok());
 
         let mut storage = InvalidatedIdsStorage::new(&invalidated_ids_dir, 1024);

--- a/rs/index/src/multi_spann/user_index_info.rs
+++ b/rs/index/src/multi_spann/user_index_info.rs
@@ -70,6 +70,32 @@ impl UserIndexInfo {
     }
 }
 
+pub struct HashConfig {}
+impl Config for HashConfig {
+    type Key = u128;
+    type Value = UserIndexInfo;
+    type EncodedKey = [u8; 16];
+    type EncodedValue = [u8; 112];
+    type H = FxHashFn;
+
+    #[inline]
+    fn encode_key(k: &Self::Key) -> Self::EncodedKey {
+        k.to_le_bytes()
+    }
+    #[inline]
+    fn encode_value(v: &Self::Value) -> Self::EncodedValue {
+        v.to_le_bytes()
+    }
+    #[inline]
+    fn decode_key(k: &Self::EncodedKey) -> Self::Key {
+        u128::from_le_bytes(*k)
+    }
+    #[inline]
+    fn decode_value(v: &Self::EncodedValue) -> Self::Value {
+        UserIndexInfo::from_le_bytes(v)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -141,31 +167,5 @@ mod tests {
             original_info.ivf_pq_codebook_len,
             deserialized_info.ivf_pq_codebook_len
         );
-    }
-}
-
-pub struct HashConfig {}
-impl Config for HashConfig {
-    type Key = u128;
-    type Value = UserIndexInfo;
-    type EncodedKey = [u8; 16];
-    type EncodedValue = [u8; 112];
-    type H = FxHashFn;
-
-    #[inline]
-    fn encode_key(k: &Self::Key) -> Self::EncodedKey {
-        k.to_le_bytes()
-    }
-    #[inline]
-    fn encode_value(v: &Self::Value) -> Self::EncodedValue {
-        v.to_le_bytes()
-    }
-    #[inline]
-    fn decode_key(k: &Self::EncodedKey) -> Self::Key {
-        u128::from_le_bytes(*k)
-    }
-    #[inline]
-    fn decode_value(v: &Self::EncodedValue) -> Self::Value {
-        UserIndexInfo::from_le_bytes(v)
     }
 }

--- a/rs/index/src/multi_spann/writer.rs
+++ b/rs/index/src/multi_spann/writer.rs
@@ -111,7 +111,7 @@ impl MultiSpannWriter {
         no_quantizer.write_to_directory(&centroid_quantizer_directory)?;
 
         // IVF quantizer
-        Self::write_common_ivf_quantizer(&ivf_directory, &multi_spann.config())?;
+        Self::write_common_ivf_quantizer(&ivf_directory, multi_spann.config())?;
 
         // Centroids index
         let mut hnsw_index_file = File::create(format!("{}/index", hnsw_directory))?;
@@ -229,7 +229,7 @@ impl MultiSpannWriter {
         // Write user index infos
         let mut hash_table = HashTableOwned::<HashConfig>::with_capacity(user_ids.len(), 90);
         for user_index_info in user_index_infos.iter() {
-            hash_table.insert(&user_index_info.user_id, &user_index_info);
+            hash_table.insert(&user_index_info.user_id, user_index_info);
         }
         let serialized = hash_table.raw_bytes();
         let user_index_info_file = format!("{}/user_index_info", base_directory);

--- a/rs/index/src/optimizers/merge.rs
+++ b/rs/index/src/optimizers/merge.rs
@@ -11,6 +11,12 @@ pub struct MergeOptimizer<Q: Quantizer + Clone> {
     _marker: std::marker::PhantomData<Q>,
 }
 
+impl<Q: Quantizer + Clone + Send + Sync> Default for MergeOptimizer<Q> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<Q: Quantizer + Clone + Send + Sync> MergeOptimizer<Q> {
     pub fn new() -> Self {
         Self {

--- a/rs/index/src/optimizers/noop.rs
+++ b/rs/index/src/optimizers/noop.rs
@@ -12,6 +12,12 @@ pub struct NoopOptimizer<Q: Quantizer + Clone + Send + Sync> {
 
 /// This optimizer does nothing. It just copies the original segment to a new segment.
 /// Useful for testing the optimizer framework.
+impl<Q: Quantizer + Clone + Send + Sync> Default for NoopOptimizer<Q> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<Q: Quantizer + Clone + Send + Sync> NoopOptimizer<Q> {
     pub fn new() -> Self {
         Self {
@@ -35,8 +41,10 @@ impl<Q: Quantizer + Clone + Send + Sync> SegmentOptimizer<Q> for NoopOptimizer<Q
             std::fs::create_dir_all(pending_segment_path.clone()).unwrap_or_default();
 
             // Copy the inner segment's contents to the new data directory
-            let mut options = CopyOptions::default();
-            options.content_only = true; // This ensures we copy only the contents, not the directory itself
+            let options = CopyOptions {
+                content_only: true, // This ensures we copy only the contents, not the directory itself
+                ..CopyOptions::default()
+            };
             fs_extra::dir::copy(inner_segment_path, pending_segment_path, &options)?;
         }
         Ok(())

--- a/rs/index/src/optimizers/vacuum.rs
+++ b/rs/index/src/optimizers/vacuum.rs
@@ -11,6 +11,12 @@ pub struct VacuumOptimizer<Q: Quantizer + Clone> {
     _marker: std::marker::PhantomData<Q>,
 }
 
+impl<Q: Quantizer + Clone + Send + Sync> Default for VacuumOptimizer<Q> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<Q: Quantizer + Clone + Send + Sync> VacuumOptimizer<Q> {
     pub fn new() -> Self {
         Self {

--- a/rs/index/src/posting_list/fixed_file.rs
+++ b/rs/index/src/posting_list/fixed_file.rs
@@ -66,13 +66,13 @@ mod tests {
         let mut appendable_storage =
             FileBackedAppendablePostingListStorage::new(base_directory.clone(), 1024, 4096);
         appendable_storage
-            .append(&vec![1, 2, 3, 4])
+            .append(&[1, 2, 3, 4])
             .expect("Failed to append posting list");
         appendable_storage
-            .append(&vec![5, 6, 7, 8])
+            .append(&[5, 6, 7, 8])
             .expect("Failed to append posting list");
         appendable_storage
-            .append(&vec![9, 10, 11, 12])
+            .append(&[9, 10, 11, 12])
             .expect("Failed to append posting list");
 
         let vectors_path = format!("{}/vector_storage", base_directory);

--- a/rs/index/src/posting_list/mod.rs
+++ b/rs/index/src/posting_list/mod.rs
@@ -42,7 +42,7 @@ impl<'a> PostingList<'a> {
     }
 
     pub fn new() -> Result<Self> {
-        Ok(PostingList::new_with_slices(Vec::new())?)
+        PostingList::new_with_slices(Vec::new())
     }
 
     pub fn iter(&'a self) -> PostingListIterator<'a> {

--- a/rs/index/src/posting_list/storage.rs
+++ b/rs/index/src/posting_list/storage.rs
@@ -24,6 +24,10 @@ impl PostingListStorage {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn get_centroid(&self, id: usize) -> Result<&[f32]> {
         match self {
             PostingListStorage::FixedLocalFile(storage) => storage.get_centroid(id),

--- a/rs/index/src/query/iters/ids_iter.rs
+++ b/rs/index/src/query/iters/ids_iter.rs
@@ -228,4 +228,13 @@ mod tests {
         assert_eq!(iter.next(), None);
         assert_eq!(iter.doc_id(), None);
     }
+
+    #[test]
+    fn test_ids_iter_dedup() {
+        let ids = vec![1, 1, 1, 1];
+        let mut iter = IdsIter::new(ids);
+
+        assert_eq!(iter.next(), Some(1));
+        assert_eq!(iter.next(), None);
+    }
 }

--- a/rs/index/src/query/iters/mod.rs
+++ b/rs/index/src/query/iters/mod.rs
@@ -159,40 +159,4 @@ mod integration_tests {
         }
         assert_eq!(results, vec![2, 3, 5, 6]);
     }
-
-    #[test]
-    fn test_empty_and() {
-        // AND of empty: should yield nothing
-        let mut iter = AndIter::new(vec![]);
-        assert_eq!(iter.next(), None);
-    }
-
-    #[test]
-    fn test_empty_or() {
-        // OR of empty: should yield nothing
-        let mut iter = OrIter::new(vec![]);
-        assert_eq!(iter.next(), None);
-    }
-
-    #[test]
-    fn test_and_with_empty_child() {
-        // AND with one child empty: should yield nothing
-        let a = ids(&[1, 2, 3]);
-        let b = ids(&[]);
-        let mut iter = AndIter::new(vec![a, b]);
-        assert_eq!(iter.next(), None);
-    }
-
-    #[test]
-    fn test_or_with_empty_child() {
-        // OR with one child empty: should yield the non-empty child
-        let a = ids(&[1, 2, 3]);
-        let b = ids(&[]);
-        let mut iter = OrIter::new(vec![a, b]);
-        let mut results = Vec::new();
-        while let Some(doc) = iter.next() {
-            results.push(doc);
-        }
-        assert_eq!(results, vec![1, 2, 3]);
-    }
 }

--- a/rs/index/src/spann/builder.rs
+++ b/rs/index/src/spann/builder.rs
@@ -174,8 +174,7 @@ impl SpannBuilder {
         })
     }
 
-    #[allow(unused_variables)]
-    pub fn add(&mut self, doc_id: u128, data: &[f32]) -> Result<()> {
+    pub fn add(&mut self, doc_id: u128, data: &[f32]) -> Result<u32> {
         self.ivf_builder.add_vector(doc_id, data)
     }
 

--- a/rs/index/src/terms/builder.rs
+++ b/rs/index/src/terms/builder.rs
@@ -34,15 +34,12 @@ impl TermBuilder {
         }
         #[cfg(debug_assertions)]
         {
-            log::debug!("Adding doc: {}, term: {}", doc_id, key);
+            log::debug!("Adding doc: {doc_id}, term: {key}");
         }
 
         let term_id = self.persist_and_get_term_id(key);
         self.scratch_file.write(doc_id, term_id)?;
-        self.posting_lists
-            .entry(term_id)
-            .or_insert_with(Vec::new)
-            .push(doc_id);
+        self.posting_lists.entry(term_id).or_default().push(doc_id);
         Ok(())
     }
 

--- a/rs/index/src/terms/builder.rs
+++ b/rs/index/src/terms/builder.rs
@@ -6,40 +6,40 @@ use utils::on_disk_ordered_map::builder::OnDiskOrderedMapBuilder;
 
 use super::scratch::Scratch;
 
+/// Single user term builder.
 pub struct TermBuilder {
+    /// Map from term string to term ID.
     pub term_map: OnDiskOrderedMapBuilder,
     next_term_id: u64,
     scratch_file: Scratch,
-    posting_lists: HashMap<u64, Vec<u64>>,
+    /// In-memory posting lists for each term ID. Each posting list is a list of point ID (u32).
+    posting_lists: HashMap<u64, Vec<u32>>,
 
     built: bool,
 }
 
 impl TermBuilder {
-    pub fn new(dir: &str) -> Self {
-        let dir_path = Path::new(dir);
-        let scratch_file_path = dir_path.join("scratch.tmp");
-        Self {
+    pub fn new(scratch_file_path: &Path) -> Result<Self> {
+        Ok(Self {
             term_map: OnDiskOrderedMapBuilder::new(),
             next_term_id: 0,
-            scratch_file: Scratch::new(scratch_file_path.as_path().to_str().unwrap()),
+            scratch_file: Scratch::new(scratch_file_path)?,
             posting_lists: HashMap::new(),
             built: false,
-        }
+        })
     }
 
-    pub fn add(&mut self, doc_id: u64, key: String) -> Result<()> {
+    pub fn add(&mut self, point_id: u32, key: String) -> Result<()> {
         if self.built {
             return Err(anyhow!("TermBuilder is already built"));
         }
-        #[cfg(debug_assertions)]
-        {
-            log::debug!("Adding doc: {doc_id}, term: {key}");
-        }
 
         let term_id = self.persist_and_get_term_id(key);
-        self.scratch_file.write(doc_id, term_id)?;
-        self.posting_lists.entry(term_id).or_default().push(doc_id);
+        self.scratch_file.write(point_id, term_id)?;
+        self.posting_lists
+            .entry(term_id)
+            .or_default()
+            .push(point_id);
         Ok(())
     }
 
@@ -76,15 +76,66 @@ impl TermBuilder {
         self.next_term_id
     }
 
-    pub fn get_posting_list(&self, term: &str) -> Option<&Vec<u64>> {
+    pub fn get_posting_list(&self, term: &str) -> Option<&[u32]> {
         if let Some(term_id) = self.term_map.get_value(term) {
             return self.get_posting_list_by_id(term_id);
         }
         None
     }
 
-    pub fn get_posting_list_by_id(&self, term_id: u64) -> Option<&Vec<u64>> {
-        self.posting_lists.get(&term_id)
+    pub fn get_posting_list_by_id(&self, term_id: u64) -> Option<&[u32]> {
+        self.posting_lists.get(&term_id).map(|v| v.as_slice())
+    }
+}
+
+/// Builer struct for multiple users, each with their own TermBuilder.
+pub struct MultiTermBuilder {
+    /// Map from user ID to its corresponding TermBuilder.
+    inner_builders: HashMap<u128, TermBuilder>,
+    /// Base directory for the term builders' scratch files.
+    base_directory: String,
+    /// Whether the builders have been built.
+    is_built: bool,
+}
+
+impl MultiTermBuilder {
+    pub fn new(base_directory: String) -> Self {
+        Self {
+            inner_builders: HashMap::new(),
+            base_directory,
+            is_built: false,
+        }
+    }
+
+    pub fn builders_iter_mut(&mut self) -> impl Iterator<Item = (&u128, &mut TermBuilder)> {
+        self.inner_builders.iter_mut()
+    }
+
+    pub fn add(&mut self, user_id: u128, point_id: u32, key: String) -> Result<()> {
+        let builder = match self.inner_builders.entry(user_id) {
+            // Use existing builder
+            std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            // Create a new builder
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let scratch_file_path =
+                    Path::new(&self.base_directory).join(format!("scratch_user_{}.tmp", user_id));
+                let new_builder = TermBuilder::new(&scratch_file_path)?;
+                // Insert and get mutable reference
+                entry.insert(new_builder)
+            }
+        };
+        builder.add(point_id, key)
+    }
+
+    pub fn build(&mut self) -> Result<()> {
+        if self.is_built {
+            return Err(anyhow!("MultiTermBuilder is already built"));
+        }
+        for (_, builder) in self.inner_builders.iter_mut() {
+            builder.build()?;
+        }
+        self.is_built = true;
+        Ok(())
     }
 }
 
@@ -97,9 +148,9 @@ mod tests {
     #[test]
     fn test_term_builder() {
         let tmp_dir = TempDir::new("test_term_builder").unwrap();
-        let base_directory = tmp_dir.path().to_str().unwrap();
+        let scratch_file_path = tmp_dir.path().join("scratch.tmp");
 
-        let mut builder = TermBuilder::new(base_directory);
+        let mut builder = TermBuilder::new(scratch_file_path.as_path()).unwrap();
         builder.add(0, "a".to_string()).unwrap();
         builder.add(0, "c".to_string()).unwrap();
         builder.add(1, "b".to_string()).unwrap();
@@ -108,5 +159,95 @@ mod tests {
         assert_eq!(*builder.get_posting_list("a").unwrap(), vec![0]);
         assert_eq!(*builder.get_posting_list("b").unwrap(), vec![1]);
         assert_eq!(*builder.get_posting_list("c").unwrap(), vec![0, 2]);
+    }
+
+    #[test]
+    fn test_multi_term_builder() {
+        let tmp_dir = TempDir::new("test_multi_term_builder").unwrap();
+        let base_directory = tmp_dir.path().to_str().unwrap().to_string();
+
+        let mut multi_builder = MultiTermBuilder::new(base_directory);
+
+        // Add terms for different users
+        let user1 = 123u128;
+        let user2 = 456u128;
+
+        // User 1: Add some terms
+        multi_builder.add(user1, 0, "apple".to_string()).unwrap();
+        multi_builder.add(user1, 1, "banana".to_string()).unwrap();
+        multi_builder.add(user1, 2, "apple".to_string()).unwrap(); // Same term, different point
+
+        // User 2: Add some terms (can have same terms as user1)
+        multi_builder.add(user2, 0, "apple".to_string()).unwrap();
+        multi_builder.add(user2, 1, "orange".to_string()).unwrap();
+        multi_builder.add(user2, 2, "grape".to_string()).unwrap();
+
+        // Build all user builders
+        multi_builder.build().unwrap();
+
+        // Test that we can iterate through builders
+        let mut builder_count = 0;
+        for (user_id, builder) in multi_builder.builders_iter_mut() {
+            builder_count += 1;
+
+            match *user_id {
+                123 => {
+                    // User 1 should have 2 terms (apple, banana)
+                    assert_eq!(builder.num_terms(), 2);
+                    assert_eq!(*builder.get_posting_list("apple").unwrap(), vec![0, 2]);
+                    assert_eq!(*builder.get_posting_list("banana").unwrap(), vec![1]);
+                }
+                456 => {
+                    // User 2 should have 3 terms (apple, orange, grape)
+                    assert_eq!(builder.num_terms(), 3);
+                    assert_eq!(*builder.get_posting_list("apple").unwrap(), vec![0]);
+                    assert_eq!(*builder.get_posting_list("orange").unwrap(), vec![1]);
+                    assert_eq!(*builder.get_posting_list("grape").unwrap(), vec![2]);
+                }
+                _ => panic!("Unexpected user_id: {}", user_id),
+            }
+        }
+
+        // Should have exactly 2 users
+        assert_eq!(builder_count, 2);
+    }
+
+    #[test]
+    fn test_multi_term_builder_error_handling() {
+        let tmp_dir = TempDir::new("test_multi_term_builder_error").unwrap();
+        let base_directory = tmp_dir.path().to_str().unwrap().to_string();
+
+        let mut multi_builder = MultiTermBuilder::new(base_directory);
+
+        // Add some terms
+        multi_builder.add(123u128, 0, "test".to_string()).unwrap();
+
+        // Build once
+        multi_builder.build().unwrap();
+
+        // Try to build again - should fail
+        let result = multi_builder.build();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("already built"));
+
+        // Try to add after building - should fail at the individual builder level
+        let result = multi_builder.add(123u128, 1, "new_term".to_string());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("already built"));
+    }
+
+    #[test]
+    fn test_multi_term_builder_empty() {
+        let tmp_dir = TempDir::new("test_multi_term_builder_empty").unwrap();
+        let base_directory = tmp_dir.path().to_str().unwrap().to_string();
+
+        let mut multi_builder = MultiTermBuilder::new(base_directory);
+
+        // Build without adding any terms
+        multi_builder.build().unwrap();
+
+        // Should have no builders
+        let builder_count = multi_builder.builders_iter_mut().count();
+        assert_eq!(builder_count, 0);
     }
 }

--- a/rs/index/src/terms/mod.rs
+++ b/rs/index/src/terms/mod.rs
@@ -1,4 +1,4 @@
 pub mod builder;
 pub mod index;
-pub mod scratch;
+mod scratch;
 pub mod writer;

--- a/rs/index/src/terms/scratch.rs
+++ b/rs/index/src/terms/scratch.rs
@@ -1,5 +1,6 @@
 use std::fs::{File, OpenOptions};
 use std::io::Write;
+use std::path::Path;
 
 use anyhow::Result;
 
@@ -8,20 +9,20 @@ pub struct Scratch {
 }
 
 impl Scratch {
-    pub fn new(file_path: &str) -> Self {
+    pub fn new(file_path: &Path) -> std::io::Result<Self> {
         // Append only
         let file = OpenOptions::new()
             .append(true)
             .create(true)
-            .open(file_path)
-            .unwrap();
+            .open(file_path)?;
 
-        Self { file }
+        Ok(Self { file })
     }
 
-    pub fn write(&mut self, doc_id: u64, term_id: u64) -> Result<()> {
-        let mut buffer = Vec::with_capacity(16);
-        buffer.extend_from_slice(&doc_id.to_le_bytes());
+    pub fn write(&mut self, point_id: u32, term_id: u64) -> Result<()> {
+        let mut buffer =
+            Vec::with_capacity(std::mem::size_of::<u32>() + std::mem::size_of::<u64>());
+        buffer.extend_from_slice(&point_id.to_le_bytes());
         buffer.extend_from_slice(&term_id.to_le_bytes());
         self.file.write_all(&buffer)?;
 

--- a/rs/index/src/terms/writer.rs
+++ b/rs/index/src/terms/writer.rs
@@ -84,7 +84,7 @@ impl TermWriter {
             let posting_list = builder.get_posting_list_by_id(term_id).unwrap();
             let mut encoder =
                 EliasFano::new_encoder(*posting_list.last().unwrap(), posting_list.len());
-            encoder.encode_batch(&posting_list).unwrap();
+            encoder.encode_batch(posting_list).unwrap();
             let len = encoder.write(&mut pl_writer)?;
             debug!(
                 "[write] Term ID: {}, Offset: {}, Length: {}",
@@ -136,22 +136,22 @@ impl TermWriter {
         append_file_to_writer(term_map_path.as_str(), &mut combined_writer)?;
         total_size += term_map_len as usize;
 
-        let padding = 8 - (total_size % 8) as usize;
+        let padding = 8 - (total_size % 8);
         if padding != 8 {
             let padding_buffer = vec![0; padding];
             total_size += wrap_write(&mut combined_writer, &padding_buffer)?;
         }
 
         append_file_to_writer(offset_path.as_str(), &mut combined_writer)?;
-        total_size += offset_len as usize;
-        let padding = 8 - (total_size % 8) as usize;
+        total_size += offset_len;
+        let padding = 8 - (total_size % 8);
         if padding != 8 {
             let padding_buffer = vec![0; padding];
             total_size += wrap_write(&mut combined_writer, &padding_buffer)?;
         }
 
         append_file_to_writer(posting_list_path.as_str(), &mut combined_writer)?;
-        total_size += last_pl_offset as usize;
+        total_size += last_pl_offset;
         combined_writer.flush()?;
 
         debug!("Total size: {}", total_size);

--- a/rs/index/src/terms/writer.rs
+++ b/rs/index/src/terms/writer.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 use std::io::{BufWriter, Write};
+use std::path::Path;
 
 use anyhow::{anyhow, Result};
 use compression::compression::IntSeqEncoder;
@@ -8,7 +9,7 @@ use log::debug;
 use utils::io::{append_file_to_writer, wrap_write};
 use utils::on_disk_ordered_map::encoder::{IntegerCodec, VarintIntegerCodec};
 
-use crate::terms::builder::TermBuilder;
+use crate::terms::builder::{MultiTermBuilder, TermBuilder};
 
 pub struct TermWriter {
     base_dir: String,
@@ -165,29 +166,308 @@ impl TermWriter {
     }
 }
 
+pub struct MultiTermWriter {
+    base_dir: String,
+}
+
+impl MultiTermWriter {
+    pub fn new(base_dir: String) -> Self {
+        Self { base_dir }
+    }
+
+    pub fn write(&self, multi_builder: &mut MultiTermBuilder) -> Result<()> {
+        for (user_id, builder) in multi_builder.builders_iter_mut() {
+            let user_dir = Path::new(&self.base_dir).join(format!("user_{}", user_id));
+            std::fs::create_dir_all(&user_dir)?;
+
+            let writer = TermWriter::new(
+                user_dir
+                    .to_str()
+                    .expect("user_dir should be valid UTF-8")
+                    .to_string(),
+            );
+            writer.write(builder)?;
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use super::*;
 
     #[test]
     fn test_term_writer() {
         let tmp_dir = tempdir::TempDir::new("test_term_writer").unwrap();
-        let base_directory = tmp_dir.path().to_str().unwrap();
+        let base_directory = tmp_dir.path();
 
-        let mut builder = TermBuilder::new(base_directory);
+        let mut builder = TermBuilder::new(base_directory.join("scratch.tmp").as_path()).unwrap();
         for i in 0..10 {
             builder.add(i, format!("key{}", i % 3)).unwrap();
         }
 
         builder.build().unwrap();
 
-        let writer = TermWriter::new(base_directory.to_string());
+        let base_dir_str = base_directory.to_str().unwrap().to_string();
+        let writer = TermWriter::new(base_dir_str.clone());
         writer.write(&mut builder).unwrap();
 
         // Check the files
-        let combined_path = format!("{}/combined", base_directory);
+        let combined_path = format!("{}/combined", base_dir_str);
         let combined_file = File::open(combined_path.as_str()).unwrap();
         let combined_file_len = combined_file.metadata().unwrap().len();
         assert_eq!(combined_file_len, 216);
+    }
+
+    #[test]
+    fn test_multi_term_writer() {
+        let tmp_dir = tempdir::TempDir::new("test_multi_term_writer").unwrap();
+        let base_directory = tmp_dir.path().to_str().unwrap().to_string();
+
+        let mut multi_builder = MultiTermBuilder::new(base_directory.clone());
+
+        // Add terms for multiple users
+        let user1 = 123u128;
+        let user2 = 456u128;
+        let user3 = 789u128;
+
+        // User 1: Add some terms
+        multi_builder
+            .add(user1, 0, "apple:red".to_string())
+            .unwrap();
+        multi_builder
+            .add(user1, 1, "banana:yellow".to_string())
+            .unwrap();
+        multi_builder
+            .add(user1, 2, "apple:green".to_string())
+            .unwrap();
+
+        // User 2: Add different terms
+        multi_builder
+            .add(user2, 0, "car:toyota".to_string())
+            .unwrap();
+        multi_builder
+            .add(user2, 1, "car:honda".to_string())
+            .unwrap();
+        multi_builder
+            .add(user2, 2, "bike:yamaha".to_string())
+            .unwrap();
+        multi_builder
+            .add(user2, 3, "car:toyota".to_string())
+            .unwrap(); // Duplicate term
+
+        // User 3: Add minimal terms
+        multi_builder
+            .add(user3, 0, "test:value".to_string())
+            .unwrap();
+
+        // Build all user builders
+        multi_builder.build().unwrap();
+
+        // Write using MultiTermWriter
+        let multi_writer = MultiTermWriter::new(base_directory.clone());
+        multi_writer.write(&mut multi_builder).unwrap();
+
+        // Verify user directories were created
+        let user1_dir = format!("{}/user_{}", base_directory, user1);
+        let user2_dir = format!("{}/user_{}", base_directory, user2);
+        let user3_dir = format!("{}/user_{}", base_directory, user3);
+
+        assert!(fs::metadata(&user1_dir).unwrap().is_dir());
+        assert!(fs::metadata(&user2_dir).unwrap().is_dir());
+        assert!(fs::metadata(&user3_dir).unwrap().is_dir());
+
+        // Verify combined files exist for each user
+        let user1_combined = format!("{}/combined", user1_dir);
+        let user2_combined = format!("{}/combined", user2_dir);
+        let user3_combined = format!("{}/combined", user3_dir);
+
+        assert!(fs::metadata(&user1_combined).unwrap().is_file());
+        assert!(fs::metadata(&user2_combined).unwrap().is_file());
+        assert!(fs::metadata(&user3_combined).unwrap().is_file());
+
+        // Verify file sizes are reasonable (not empty)
+        assert!(fs::metadata(&user1_combined).unwrap().len() > 0);
+        assert!(fs::metadata(&user2_combined).unwrap().len() > 0);
+        assert!(fs::metadata(&user3_combined).unwrap().len() > 0);
+
+        // User 2 should have larger file (more terms)
+        let user1_size = fs::metadata(&user1_combined).unwrap().len();
+        let user2_size = fs::metadata(&user2_combined).unwrap().len();
+        let user3_size = fs::metadata(&user3_combined).unwrap().len();
+
+        assert!(user2_size >= user1_size); // User 2 has same or more terms
+        assert!(user1_size > user3_size); // User 1 has more terms than user 3
+    }
+
+    #[test]
+    fn test_multi_term_writer_empty_builder() {
+        let tmp_dir = tempdir::TempDir::new("test_multi_term_writer_empty").unwrap();
+        let base_directory = tmp_dir.path().to_str().unwrap().to_string();
+
+        let mut multi_builder = MultiTermBuilder::new(base_directory.clone());
+
+        // Build without adding any terms
+        multi_builder.build().unwrap();
+
+        // Write using MultiTermWriter
+        let multi_writer = MultiTermWriter::new(base_directory.clone());
+        multi_writer.write(&mut multi_builder).unwrap();
+
+        // Should not create any user directories
+        let entries = fs::read_dir(&base_directory).unwrap();
+        let user_dirs: Vec<_> = entries
+            .filter_map(|entry| {
+                let entry = entry.ok()?;
+                let name = entry.file_name().to_string_lossy().to_string();
+                if name.starts_with("user_") {
+                    Some(name)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert!(
+            user_dirs.is_empty(),
+            "Should not create user directories for empty builder"
+        );
+    }
+
+    #[test]
+    fn test_multi_term_writer_single_user() {
+        let tmp_dir = tempdir::TempDir::new("test_multi_term_writer_single").unwrap();
+        let base_directory = tmp_dir.path().to_str().unwrap().to_string();
+
+        let mut multi_builder = MultiTermBuilder::new(base_directory.clone());
+
+        let user_id = 42u128;
+        multi_builder
+            .add(user_id, 0, "single:term".to_string())
+            .unwrap();
+        multi_builder
+            .add(user_id, 1, "another:term".to_string())
+            .unwrap();
+
+        multi_builder.build().unwrap();
+
+        let multi_writer = MultiTermWriter::new(base_directory.clone());
+        multi_writer.write(&mut multi_builder).unwrap();
+
+        // Should create exactly one user directory
+        let user_dir = format!("{}/user_{}", base_directory, user_id);
+        assert!(fs::metadata(&user_dir).unwrap().is_dir());
+
+        // Combined file should exist
+        let combined_path = format!("{}/combined", user_dir);
+        assert!(fs::metadata(&combined_path).unwrap().is_file());
+        assert!(fs::metadata(&combined_path).unwrap().len() > 0);
+    }
+
+    #[test]
+    fn test_multi_term_writer_directory_creation() {
+        let tmp_dir = tempdir::TempDir::new("test_multi_term_writer_dirs").unwrap();
+        let base_directory = tmp_dir.path().to_str().unwrap().to_string();
+
+        // Use nested directory structure
+        let nested_base = format!("{}/nested/path", base_directory);
+        fs::create_dir_all(&nested_base).unwrap();
+        let mut multi_builder = MultiTermBuilder::new(nested_base.clone());
+
+        let user_id = 999u128;
+        multi_builder
+            .add(user_id, 0, "nested:test".to_string())
+            .unwrap();
+        multi_builder.build().unwrap();
+
+        let multi_writer = MultiTermWriter::new(nested_base.clone());
+        multi_writer.write(&mut multi_builder).unwrap();
+
+        // Should create nested directory structure
+        let user_dir = format!("{}/user_{}", nested_base, user_id);
+        assert!(fs::metadata(&user_dir).unwrap().is_dir());
+
+        let combined_path = format!("{}/combined", user_dir);
+        assert!(fs::metadata(&combined_path).unwrap().is_file());
+    }
+
+    #[test]
+    fn test_multi_term_writer_error_propagation() {
+        let tmp_dir = tempdir::TempDir::new("test_multi_term_writer_error").unwrap();
+        let base_directory = tmp_dir.path().to_str().unwrap().to_string();
+
+        let mut multi_builder = MultiTermBuilder::new(base_directory.clone());
+
+        let user_id = 555u128;
+        multi_builder
+            .add(user_id, 0, "error:test".to_string())
+            .unwrap();
+
+        // Don't build - should cause error when writing
+        let multi_writer = MultiTermWriter::new(base_directory.clone());
+        let result = multi_writer.write(&mut multi_builder);
+
+        // Should return error because builder wasn't built
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not built"));
+    }
+
+    #[test]
+    fn test_multi_term_writer_user_isolation() {
+        let tmp_dir = tempdir::TempDir::new("test_multi_term_writer_isolation").unwrap();
+        let base_directory = tmp_dir.path().to_str().unwrap().to_string();
+
+        let mut multi_builder = MultiTermBuilder::new(base_directory.clone());
+
+        let user1 = 111u128;
+        let user2 = 222u128;
+
+        // Both users add the same term - should be isolated
+        multi_builder
+            .add(user1, 0, "shared:term".to_string())
+            .unwrap();
+        multi_builder
+            .add(user1, 1, "user1:unique".to_string())
+            .unwrap();
+
+        multi_builder
+            .add(user2, 0, "shared:term".to_string())
+            .unwrap(); // Same term name
+        multi_builder
+            .add(user2, 1, "user2:unique".to_string())
+            .unwrap();
+
+        multi_builder.build().unwrap();
+
+        let multi_writer = MultiTermWriter::new(base_directory.clone());
+        multi_writer.write(&mut multi_builder).unwrap();
+
+        // Both user directories should exist
+        let user1_dir = format!("{}/user_{}", base_directory, user1);
+        let user2_dir = format!("{}/user_{}", base_directory, user2);
+
+        assert!(fs::metadata(&user1_dir).unwrap().is_dir());
+        assert!(fs::metadata(&user2_dir).unwrap().is_dir());
+
+        // Both should have their own combined files
+        let user1_combined = format!("{}/combined", user1_dir);
+        let user2_combined = format!("{}/combined", user2_dir);
+
+        assert!(fs::metadata(&user1_combined).unwrap().is_file());
+        assert!(fs::metadata(&user2_combined).unwrap().is_file());
+
+        // Files should be roughly similar size (both have 2 terms)
+        let user1_size = fs::metadata(&user1_combined).unwrap().len();
+        let user2_size = fs::metadata(&user2_combined).unwrap().len();
+
+        // Size difference should be 0
+        assert!(
+            user1_size == user2_size,
+            "User file sizes too different: {} vs {}",
+            user1_size,
+            user2_size
+        );
     }
 }

--- a/rs/index/src/wal/wal.rs
+++ b/rs/index/src/wal/wal.rs
@@ -169,15 +169,20 @@ impl Wal {
 
         // Sync files that contain flushed_seq_no or have sequence numbers less than flushed_seq_no
         for file in self.files.iter() {
-            let file_start_seq_no = file.get_start_seq_no();
+            // let file_start_seq_no = file.get_start_seq_no();
             let file_last_seq_no = file.get_last_seq_no();
 
-            // Check if flushed_seq_no is within the range of the file or less than the file's range
-            if file_start_seq_no <= current_synced_seq_no
-                && file_last_seq_no >= current_synced_seq_no
-            {
-                file.sync_data()?;
-            } else if file_start_seq_no > current_synced_seq_no {
+            // // Check if flushed_seq_no is within the range of the file or less than the file's range
+            // if file_start_seq_no <= current_synced_seq_no
+            //     && file_last_seq_no >= current_synced_seq_no
+            // {
+            //     file.sync_data()?;
+            // } else if file_start_seq_no > current_synced_seq_no {
+            //     file.sync_data()?;
+            // }
+
+            // Check if file needs to be synced based on current_synced_seq_no
+            if file_last_seq_no >= current_synced_seq_no {
                 file.sync_data()?;
             }
         }

--- a/rs/index_server/Cargo.toml
+++ b/rs/index_server/Cargo.toml
@@ -3,6 +3,9 @@ name = "index_server"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 clap = { version = "4.1.4", features = ["derive"] }

--- a/rs/index_writer/Cargo.toml
+++ b/rs/index_writer/Cargo.toml
@@ -3,6 +3,9 @@ name = "index_writer"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "hnsw_reindexer"
 path = "src/hnsw_reindexer.rs"

--- a/rs/index_writer/src/index_writer.rs
+++ b/rs/index_writer/src/index_writer.rs
@@ -96,7 +96,7 @@ impl IndexWriter {
             }
         }
 
-        std::fs::create_dir_all(&path)?;
+        std::fs::create_dir_all(path)?;
 
         info!("Start writing index");
         let hnsw_writer = HnswWriter::new(path.to_string());
@@ -225,7 +225,7 @@ impl IndexWriter {
         info!("Start building index");
         ivf_builder.build()?;
 
-        std::fs::create_dir_all(&path)?;
+        std::fs::create_dir_all(path)?;
 
         info!("Start writing index");
         let ivf_writer = IvfWriter::<_, E, D>::new(path.to_string(), quantizer);
@@ -274,7 +274,7 @@ impl IndexWriter {
 
         // Define the writer function for ProductQuantizer
         let pq_writer_fn =
-            |directory: &String, pq: &ProductQuantizer<D>| pq.write_to_directory(&directory);
+            |directory: &String, pq: &ProductQuantizer<D>| pq.write_to_directory(directory);
 
         self.write_quantizer_and_build_ivf_index::<_, E, D, _>(
             input,
@@ -303,7 +303,7 @@ impl IndexWriter {
 
         // Define the writer function for NoQuantizer
         let noq_writer_fn =
-            |directory: &String, noq: &NoQuantizer<D>| noq.write_to_directory(&directory);
+            |directory: &String, noq: &NoQuantizer<D>| noq.write_to_directory(directory);
 
         self.write_quantizer_and_build_ivf_index::<_, E, D, _>(
             input,
@@ -386,7 +386,7 @@ impl IndexWriter {
             num_features: index_writer_config.base_config.dimension,
             pq_subvector_dimension: index_writer_config.quantizer_config.subvector_dimension,
             pq_num_bits: index_writer_config.quantizer_config.num_bits as usize,
-            pq_num_training_rows: index_writer_config.quantizer_config.num_training_rows as usize,
+            pq_num_training_rows: index_writer_config.quantizer_config.num_training_rows,
             quantizer_type: index_writer_config.quantizer_config.quantizer_type.clone(),
             pq_max_iteration: index_writer_config.ivf_config.max_iteration,
             pq_batch_size: index_writer_config.ivf_config.batch_size,

--- a/rs/index_writer/src/input/hdf5.rs
+++ b/rs/index_writer/src/input/hdf5.rs
@@ -140,7 +140,7 @@ mod tests {
         assert_eq!(result.centroids.len(), 1280);
 
         // Check the the cluster sizes are equal
-        let mut cluster_sizes = vec![0; 10];
+        let mut cluster_sizes = [0; 10];
         for assignment in &result.assignments {
             cluster_sizes[*assignment] += 1;
         }
@@ -150,11 +150,11 @@ mod tests {
             let point = &flattened_dataset[i * 128..(i + 1) * 128];
             let centroid_id = result.assignments[i];
             let centroid = &result.centroids[centroid_id * 128..(centroid_id + 1) * 128];
-            let dist = L2DistanceCalculator::calculate(&point, &centroid);
+            let dist = L2DistanceCalculator::calculate(point, centroid);
 
             for j in 0..10 {
                 let dist_to_centroid = L2DistanceCalculator::calculate(
-                    &point,
+                    point,
                     &result.centroids[j * 128..(j + 1) * 128],
                 );
                 if dist_to_centroid < dist {

--- a/rs/proto/build.rs
+++ b/rs/proto/build.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .compile_protos(&[aggregator_proto_file], &["proto"])?;
 
     let output = Command::new("cargo")
-        .args(&["fmt"])
+        .args(["fmt"])
         .output()
         .expect("Failed to execute cargo fmt");
 

--- a/rs/quantization/Cargo.toml
+++ b/rs/quantization/Cargo.toml
@@ -3,6 +3,9 @@ name = "quantization"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 approx.workspace = true

--- a/rs/quantization/benches/pq_dist.rs
+++ b/rs/quantization/benches/pq_dist.rs
@@ -42,11 +42,11 @@ fn bench_pq_distance(c: &mut Criterion) {
                 for implementation in L2DistanceCalculatorImpl::iter() {
                     group.bench_with_input(
                         BenchmarkId::new(
-                            &format!(
+                            format!(
                                 "pq_distance_{}_{}_{}",
                                 *dimension, *subvector_dimension, *num_bits
                             ),
-                            &format!("{:?}", &implementation),
+                            format!("{:?}", &implementation),
                         ),
                         &implementation,
                         |bencher, _| {

--- a/rs/quantization/src/noq/noq.rs
+++ b/rs/quantization/src/noq/noq.rs
@@ -63,7 +63,7 @@ impl<D: DistanceCalculator> WritableQuantizer for NoQuantizer<D> {
             dimension: self.dimension,
         };
         std::fs::write(
-            &format!("{}/no_op_quantizer_config.yaml", base_directory),
+            format!("{}/no_op_quantizer_config.yaml", base_directory),
             serde_yaml::to_string(&config)?,
         )?;
         Ok(())
@@ -92,7 +92,7 @@ impl<D: DistanceCalculator> NoQuantizerReader<D> {
     pub fn read(&self) -> Result<NoQuantizer<D>> {
         // Deserialieze the config
         let config = serde_yaml::from_str::<NoQuantizerConfig>(&std::fs::read_to_string(
-            &format!("{}/no_op_quantizer_config.yaml", self.base_directory),
+            format!("{}/no_op_quantizer_config.yaml", self.base_directory),
         )?)?;
         Ok(NoQuantizer::new(config.dimension))
     }

--- a/rs/quantization/src/rabitq/rabitq_builder.rs
+++ b/rs/quantization/src/rabitq/rabitq_builder.rs
@@ -32,7 +32,7 @@ impl RabitQBuilder {
     }
 
     pub fn build(&mut self) -> Result<RabitQ> {
-        assert!(self.dataset.len() > 0, "Dataset is empty");
+        assert!(!self.dataset.is_empty(), "Dataset is empty");
 
         let dataset = self.get_dataset()?;
 
@@ -71,13 +71,13 @@ impl RabitQBuilder {
     }
 
     fn get_centroid(&self, dataset: &Array2<f32>) -> Array1<f32> {
-        return dataset.mean_axis(Axis(0)).unwrap();
+        dataset.mean_axis(Axis(0)).unwrap()
     }
 
     fn generate_orthogonal_matrix(&self, d: usize) -> Result<Array2<f32>> {
         let matrix: Array2<f32> = Array2::random((d, d), StandardNormal);
         let (q, _) = matrix.qr()?;
-        return Ok(q);
+        Ok(q)
     }
 
     fn get_quantization_codes(
@@ -102,7 +102,7 @@ impl RabitQBuilder {
     fn get_quantized_vector_dot_products(
         &self,
         normalized_dataset: &Array2<f32>,
-        quantization_codes: &Vec<BitVec>,
+        quantization_codes: &[BitVec],
         p: &Array2<f32>,
     ) -> Array1<f32> {
         debug_assert!(

--- a/rs/utils/Cargo.toml
+++ b/rs/utils/Cargo.toml
@@ -3,6 +3,9 @@ name = "utils"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1.0.90"
 bitvec = "1"

--- a/rs/utils/benches/kmeans.rs
+++ b/rs/utils/benches/kmeans.rs
@@ -20,7 +20,7 @@ fn bench_kmeans(c: &mut Criterion) {
         dimension,
         kmeans_builder::KMeansVariant::Lloyd,
     );
-    for parallel in [false].iter() {
+    [false].iter().for_each(|parallel| {
         group.bench_with_input(
             BenchmarkId::new("kmeans", parallel),
             &parallel,
@@ -34,7 +34,7 @@ fn bench_kmeans(c: &mut Criterion) {
                 })
             },
         );
-    }
+    });
 }
 
 criterion_group!(benches, bench_kmeans);

--- a/rs/utils/src/bloom_filter/reader.rs
+++ b/rs/utils/src/bloom_filter/reader.rs
@@ -28,12 +28,7 @@ impl BloomFilterReader {
         let num_hash_functions = u64::from_le_bytes(metadata[8..16].try_into()?) as usize;
         let num_blocks = u64::from_le_bytes(metadata[16..HEADER_SIZE].try_into()?) as usize;
 
-        Ok(ImmutableBloomFilter::new(
-            path,
-            HEADER_SIZE,
-            num_blocks,
-            num_hash_functions,
-        )?)
+        ImmutableBloomFilter::new(path, HEADER_SIZE, num_blocks, num_hash_functions)
     }
 }
 


### PR DESCRIPTION
Now for one user, there is one `TermBuilder` that builds user-specific mappings between term ID and point IDs. Each `TermWriter` writes term index data to its designated directory: `/terms/user_{user_id}/`. 

This approach may not be desirable when number of users scales up, producing huge number of directories. Next PR will implement merging into global files (like `MultiSpann`).

Also now in `TermIndex`, a term ID gets a posting list iterator that iterates through point IDs, not doc IDs. 

Note: Since the `TermBuilder` is only used in `MutableSegment` (which is protected in a `RwLock` inside `Collection`), `TermBuilder` is not intended for concurrent access for now.