### PR TITLE
feat(terms): merge multiple users' term indexes into one file

### DIFF
--- a/rs/index/src/segment/mutable_segment.rs
+++ b/rs/index/src/segment/mutable_segment.rs
@@ -226,7 +226,7 @@ mod tests {
 
         // Check that term files are created
         let segment_dir = format!("{}/{}", base_dir, segment_name);
-        let terms_dir = format!("{}/terms/user_0", segment_dir);
+        let terms_dir = format!("{}/terms", segment_dir);
 
         // Verify the terms directory exists
         assert!(
@@ -239,27 +239,6 @@ mod tests {
         assert!(
             std::path::Path::new(&combined_file_path).exists(),
             "Combined terms file should exist"
-        );
-
-        // Verify the term_map file exists (temporary file used during building)
-        let term_map_path = format!("{}/term_map", terms_dir);
-        assert!(
-            std::path::Path::new(&term_map_path).exists(),
-            "Term map file should exist"
-        );
-
-        // Verify the posting_lists file exists (temporary file used during building)
-        let posting_lists_path = format!("{}/posting_lists", terms_dir);
-        assert!(
-            std::path::Path::new(&posting_lists_path).exists(),
-            "Posting lists file should exist"
-        );
-
-        // Verify the offsets file exists (temporary file used during building)
-        let offsets_path = format!("{}/offsets", terms_dir);
-        assert!(
-            std::path::Path::new(&offsets_path).exists(),
-            "Offsets file should exist"
         );
     }
 }

--- a/rs/index/src/terms/builder.rs
+++ b/rs/index/src/terms/builder.rs
@@ -111,6 +111,10 @@ impl MultiTermBuilder {
         self.inner_builders.iter_mut()
     }
 
+    pub fn builders_iter(&self) -> impl Iterator<Item = (&u128, &TermBuilder)> {
+        self.inner_builders.iter()
+    }
+
     pub fn add(&mut self, user_id: u128, point_id: u32, key: String) -> Result<()> {
         let builder = match self.inner_builders.entry(user_id) {
             // Use existing builder
@@ -136,6 +140,10 @@ impl MultiTermBuilder {
         }
         self.is_built = true;
         Ok(())
+    }
+
+    pub fn is_built(&self) -> bool {
+        self.is_built
     }
 }
 

--- a/rs/index/src/terms/index.rs
+++ b/rs/index/src/terms/index.rs
@@ -9,6 +9,8 @@ use ouroboros::self_referencing;
 use utils::on_disk_ordered_map::encoder::VarintIntegerCodec;
 use utils::on_disk_ordered_map::map::OnDiskOrderedMap;
 
+use crate::terms::term_index_info::TermIndexInfoHashTable;
+
 pub struct TermIndex {
     // Box the inner data to make it self-referential
     inner: TermIndexInner,
@@ -159,62 +161,100 @@ impl TermIndex {
 pub struct MultiTermIndex {
     /// Map of user ID to their [`TermIndex`]
     term_indexes: HashMap<u128, TermIndex>,
+    /// Hash table holding offsets and lengths for all users
+    user_index_info: TermIndexInfoHashTable,
+    /// Base directory for the term indexes
+    base_directory: String,
 }
 
 impl MultiTermIndex {
-    pub fn new(base_dir: &str) -> Result<Self> {
-        let mut term_indexes = HashMap::new();
+    /// Load the MultiTermIndex and the TermIndexInfo hash table
+    pub fn new(base_directory: String) -> Result<Self> {
+        // Load the user index info hash table
+        let info_file_path = format!("{}/user_term_index_info", base_directory);
+        let user_index_info = TermIndexInfoHashTable::load(info_file_path)?;
 
-        for entry in std::fs::read_dir(base_dir)? {
-            let entry = entry?;
-            if entry.file_type()?.is_dir() {
-                if let Some(user_str) = entry.file_name().to_str() {
-                    if let Ok(user_id) = user_str.parse::<u128>() {
-                        let user_dir = entry.path();
-                        let index_file_path = user_dir.join("combined");
-                        if !index_file_path.exists() {
-                            log::warn!(
-                                "Index file does not exist for user {}: {:?}",
-                                user_id,
-                                index_file_path
-                            );
-                            continue;
-                        }
-                        let term_index = TermIndex::new(
-                            index_file_path
-                                .to_str()
-                                .expect("index_file_path must be valid UTF-8 string")
-                                .to_string(),
-                            0,
-                            std::fs::metadata(&index_file_path)?.len() as usize,
-                        )?;
-                        term_indexes.insert(user_id, term_index);
-                    }
-                }
+        Ok(Self {
+            base_directory,
+            term_indexes: HashMap::new(),
+            user_index_info,
+        })
+    }
+
+    /// Lazily load or return cached TermIndex for a user
+    /// Errors: if user not found or TermIndex creation fails
+    pub fn get_or_create_index(&mut self, user_id: u128) -> Result<&TermIndex> {
+        match self.term_indexes.entry(user_id) {
+            std::collections::hash_map::Entry::Occupied(entry) => Ok(entry.into_mut()),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let index_info = self
+                    .user_index_info
+                    .hash_table
+                    .get(&user_id)
+                    .ok_or_else(|| anyhow!("User not found"))?;
+
+                let combined_path = format!("{}/combined", self.base_directory);
+                let term_index = TermIndex::new(
+                    combined_path,
+                    index_info.offset as usize,
+                    index_info.length as usize,
+                )
+                .map_err(|e| anyhow!("Failed to create TermIndex: {e}"))?;
+
+                Ok(entry.insert(term_index))
             }
         }
-
-        Ok(Self { term_indexes })
     }
 
-    pub fn get_term_index_for_user(&self, user_id: u128) -> Option<&TermIndex> {
-        self.term_indexes.get(&user_id)
+    /// Retrieve the term ID for a given user and term string
+    /// Will create/load the TermIndex for the user if not already cached
+    /// Errors: if user or term not found or TermIndex creation fails
+    pub fn get_term_id_for_user(&mut self, user_id: u128, term: &str) -> Result<u64> {
+        let term_index = self.get_or_create_index(user_id)?;
+        term_index
+            .get_term_id(term)
+            .ok_or_else(|| anyhow!("Term not found"))
     }
 
-    /// Retrieves the term ID for a given user and term string.
-    pub fn get_term_id_for_user(&self, user_id: u128, term: &str) -> Option<u64> {
-        let term_index = self.term_indexes.get(&user_id)?;
-        term_index.get_term_id(term)
+    /// Remove and return the TermIndex for a given user
+    /// Will create/load the TermIndex for the user if not already cached
+    /// Errors: if user not found or TermIndex creation fails
+    pub fn take_index_for_user(&mut self, user_id: u128) -> Result<TermIndex> {
+        self.get_or_create_index(user_id)?;
+        self.term_indexes
+            .remove(&user_id)
+            .ok_or_else(|| anyhow!("User not found"))
+    }
+
+    #[cfg(test)]
+    pub fn term_index_info(&self) -> &TermIndexInfoHashTable {
+        &self.user_index_info
+    }
+
+    /// Get posting list iterator for a given user and term ID
+    /// Will create/load the TermIndex for the user if not already cached
+    /// Errors: if user or term ID not found or TermIndex creation fails
+    pub fn get_posting_list_iterator(
+        &mut self,
+        user_id: u128,
+        term_id: u64,
+    ) -> Result<EliasFanoDecodingIterator> {
+        let term_index = self.get_or_create_index(user_id)?;
+        term_index.get_posting_list_iterator(term_id)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::path::Path;
+
     use tempdir::TempDir;
 
     use super::TermIndex;
-    use crate::terms::builder::TermBuilder;
-    use crate::terms::writer::TermWriter;
+    use crate::terms::builder::{MultiTermBuilder, TermBuilder};
+    use crate::terms::index::MultiTermIndex;
+    use crate::terms::writer::{MultiTermWriter, TermWriter};
 
     /// Tests the basic functionality of the `TermIndex` including term ID retrieval,
     /// offset and length calculation for posting lists, and iteration over posting lists.
@@ -246,7 +286,7 @@ mod tests {
         let writer = TermWriter::new(base_dir_str.clone());
         writer.write(&mut builder).unwrap();
 
-        let path = format!("{base_dir_str}/combined",);
+        let path = format!("{base_dir_str}/combined");
         let file_len = std::fs::metadata(&path).unwrap().len();
         let index = TermIndex::new(path, 0, file_len as usize).unwrap();
 
@@ -337,7 +377,7 @@ mod tests {
         for doc in it {
             banana_docs.push(doc);
         }
-        // "banana" should appear in docs 0, 1, 5, 6, 10, 11, 15, 16
+        // "banana" should appear in docs 1, 6, 11, 16
         assert_eq!(banana_docs, vec![1, 6, 11, 16]);
 
         // Verify a unique term
@@ -345,7 +385,6 @@ mod tests {
         let mut it = index.get_posting_list_iterator(unique_term_5_id).unwrap();
         assert_eq!(it.next().unwrap(), 5);
         assert!(it.next().is_none());
-
         // Verify a term that appears in many documents
         let orange_id = index.get_term_id("orange").unwrap();
         let it = index.get_posting_list_iterator(orange_id).unwrap();
@@ -353,12 +392,180 @@ mod tests {
         for doc in it {
             orange_docs.push(doc);
         }
-        // "orange" should appear in docs 0, 1, 2, 5, 6, 7, 10, 11, 12, 15, 16, 17
+        // "orange" should appear in docs 2, 7, 12, 17
         assert_eq!(orange_docs, vec![2, 7, 12, 17]);
 
-        let unique_5 = index.get_term_id("unique_term_5").unwrap();
-        let mut it = index.get_posting_list_iterator(unique_5).unwrap();
-        assert_eq!(it.next().unwrap(), 5);
-        assert!(it.next().is_none());
+        for doc_id in 0..20 {
+            let unique_term = format!("unique_term_{doc_id}");
+            let term_id = index.get_term_id(&unique_term).unwrap();
+            let mut it = index.get_posting_list_iterator(term_id).unwrap();
+            assert_eq!(it.next().unwrap(), doc_id);
+            assert!(it.next().is_none());
+        }
+    }
+
+    fn build_and_write_index(base_dir: &str) -> (Vec<u128>, MultiTermIndex) {
+        let mut multi_builder = MultiTermBuilder::new(base_dir.to_string());
+        let user1 = 1001u128;
+        let user2 = 2002u128;
+        let user3 = 3003u128;
+
+        // User 1 terms
+        multi_builder
+            .add(user1, 10, "apple:red".to_string())
+            .unwrap();
+        multi_builder
+            .add(user1, 20, "banana:yellow".to_string())
+            .unwrap();
+        multi_builder
+            .add(user1, 30, "apple:green".to_string())
+            .unwrap();
+
+        // User 2 terms
+        multi_builder
+            .add(user2, 11, "car:toyota".to_string())
+            .unwrap();
+        multi_builder
+            .add(user2, 22, "car:honda".to_string())
+            .unwrap();
+        multi_builder
+            .add(user2, 33, "bike:yamaha".to_string())
+            .unwrap();
+
+        // User 3 single term
+        multi_builder
+            .add(user3, 1, "test:value".to_string())
+            .unwrap();
+
+        multi_builder.build().unwrap();
+        let writer = MultiTermWriter::new(base_dir.to_string());
+        writer.write(&mut multi_builder).unwrap();
+
+        let index = MultiTermIndex::new(base_dir.to_string()).unwrap();
+        (vec![user1, user2, user3], index)
+    }
+
+    #[test]
+    fn test_multi_term_index_roundtrip() {
+        let tmp = TempDir::new("multi_term_index_roundtrip").unwrap();
+        let base_dir = tmp.path().to_str().unwrap().to_string();
+
+        let (users, mut index) = build_and_write_index(&base_dir);
+        let user1 = users[0];
+        let user2 = users[1];
+
+        // Term IDs should differ within the same user
+        let id_apple_red = index.get_term_id_for_user(user1, "apple:red").unwrap();
+        let id_banana = index.get_term_id_for_user(user1, "banana:yellow").unwrap();
+        assert_ne!(id_apple_red, id_banana);
+
+        // Verify isolation of lookup between users
+        assert!(
+            index
+                .get_term_id_for_user(user1, "car:toyota")
+                .unwrap_err()
+                .to_string()
+                == "Term not found",
+            "User1 should not see User2’s terms"
+        );
+        assert!(
+            index
+                .get_term_id_for_user(user2, "apple:red")
+                .unwrap_err()
+                .to_string()
+                == "Term not found",
+            "User2 should not see User1’s terms"
+        );
+
+        // Check that we can open posting list iterator and it matches builder data
+        let pl_apple: Vec<_> = index
+            .get_posting_list_iterator(user1, id_apple_red)
+            .unwrap()
+            .collect();
+        assert_eq!(pl_apple, vec![10]);
+
+        let term_id = index.get_term_id_for_user(user2, "bike:yamaha").unwrap();
+        let pl_bike: Vec<_> = index
+            .get_posting_list_iterator(user2, term_id)
+            .unwrap()
+            .collect();
+        assert_eq!(pl_bike, vec![33]);
+    }
+
+    #[test]
+    fn test_multi_term_index_empty() {
+        let tmp = TempDir::new("multi_term_index_empty").unwrap();
+        let base_dir = tmp.path().to_str().unwrap().to_string();
+
+        let mut builder = MultiTermBuilder::new(base_dir.clone());
+        builder.build().unwrap();
+
+        let writer = MultiTermWriter::new(base_dir.clone());
+        writer.write(&mut builder).unwrap();
+
+        let combined_path = format!("{}/combined", base_dir);
+        assert!(Path::new(&combined_path).exists());
+        let len = fs::metadata(&combined_path).unwrap().len();
+        assert_eq!(len, 0, "Combined file should be empty");
+
+        let index_info_path = format!("{}/user_term_index_info", base_dir);
+        assert!(Path::new(&index_info_path).exists());
+
+        let mut index = MultiTermIndex::new(base_dir.clone()).unwrap();
+        // The hash table should be empty
+        assert_eq!(index.term_index_info().hash_table.len(), 0);
+        // Attempting to get a user should fail
+        assert!(index.get_or_create_index(123u128).is_err());
+    }
+
+    #[test]
+    fn test_multi_term_index_alignment_and_ranges() {
+        let tmp = TempDir::new("multi_term_index_alignment").unwrap();
+        let base_dir = tmp.path().to_str().unwrap().to_string();
+
+        let (users, index) = build_and_write_index(&base_dir);
+        let info = index.term_index_info();
+
+        // Combined file size
+        let combined_len = fs::metadata(format!("{}/combined", base_dir))
+            .unwrap()
+            .len() as u64;
+
+        // Verify alignment and non-overlap
+        let mut last_end = 0;
+        let mut offsets = vec![];
+
+        for user_id in &users {
+            let entry = info.hash_table.get(user_id).unwrap();
+            assert_eq!(entry.offset % 8, 0, "Offset not 8-byte aligned");
+            assert!(entry.offset + entry.length <= combined_len);
+            assert!(entry.offset >= last_end, "Overlapping regions");
+            last_end = entry.offset + entry.length;
+            offsets.push(entry.offset);
+        }
+
+        // Ensure deterministic order (sorted offsets)
+        let mut sorted_offsets = offsets.clone();
+        sorted_offsets.sort();
+        assert_eq!(offsets, sorted_offsets);
+    }
+
+    #[test]
+    fn test_multi_term_index_lazy_load_cache() {
+        let tmp = TempDir::new("multi_term_index_lazy_cache").unwrap();
+        let base_dir = tmp.path().to_str().unwrap().to_string();
+
+        let (users, mut index) = build_and_write_index(&base_dir);
+        let user1 = users[0];
+
+        // First call should load
+        let first = index.get_or_create_index(user1).unwrap() as *const _;
+        // Second call should reuse
+        let second = index.get_or_create_index(user1).unwrap() as *const _;
+        assert_eq!(first, second, "Should return cached TermIndex reference");
+
+        // Should fail for unknown user
+        let unknown_user = 99999u128;
+        assert!(index.get_or_create_index(unknown_user).is_err());
     }
 }

--- a/rs/index/src/terms/mod.rs
+++ b/rs/index/src/terms/mod.rs
@@ -1,4 +1,5 @@
 pub mod builder;
 pub mod index;
 mod scratch;
+mod term_index_info;
 pub mod writer;

--- a/rs/index/src/terms/term_index_info.rs
+++ b/rs/index/src/terms/term_index_info.rs
@@ -1,0 +1,63 @@
+use std::fs::File;
+use std::path::Path;
+
+use memmap2::Mmap;
+use odht::{Config, FxHashFn, HashTableOwned};
+
+pub struct TermIndexInfo {
+    pub offset: u64,
+    pub length: u64,
+}
+
+pub struct TermIndexInfoHashTableConfig {}
+
+impl Config for TermIndexInfoHashTableConfig {
+    type Key = u128;
+    type Value = TermIndexInfo;
+
+    type EncodedKey = [u8; 16];
+    type EncodedValue = [u8; 16];
+
+    type H = FxHashFn;
+
+    #[inline]
+    fn encode_key(k: &Self::Key) -> Self::EncodedKey {
+        k.to_le_bytes()
+    }
+    #[inline]
+    fn encode_value(v: &Self::Value) -> Self::EncodedValue {
+        let mut buf = [0u8; 16];
+        buf[..8].copy_from_slice(&v.offset.to_le_bytes());
+        buf[8..].copy_from_slice(&v.length.to_le_bytes());
+        buf
+    }
+    #[inline]
+    fn decode_key(k: &Self::EncodedKey) -> Self::Key {
+        u128::from_le_bytes(*k)
+    }
+    #[inline]
+    fn decode_value(v: &Self::EncodedValue) -> Self::Value {
+        let offset = u64::from_le_bytes(v[..8].try_into().expect("v should be 16 bytes"));
+        let length = u64::from_le_bytes(v[8..].try_into().expect("v should be 16 bytes"));
+        TermIndexInfo { offset, length }
+    }
+}
+
+pub struct TermIndexInfoHashTable {
+    #[allow(dead_code)]
+    /// Needed to keep the mmap alive while using the hash table
+    pub mmap: Mmap,
+    /// The actual hash table
+    pub hash_table: HashTableOwned<TermIndexInfoHashTableConfig>,
+}
+
+impl TermIndexInfoHashTable {
+    /// Load from a file path
+    pub fn load<P: AsRef<Path>>(path: P) -> std::io::Result<Self> {
+        let file = File::open(path)?;
+        let mmap = unsafe { Mmap::map(&file)? };
+        let hash_table = HashTableOwned::<TermIndexInfoHashTableConfig>::from_raw_bytes(&mmap)
+            .expect("Failed to create hash table from mmap");
+        Ok(Self { mmap, hash_table })
+    }
+}


### PR DESCRIPTION
Now `MultiTermWriter` combines all users' term indexes into one file called `terms/combined`, and the indexes' offsets and lengths are kept in the `terms/user_term_index_info` file. Index writes in `terms/combined` are 8-byte-aligned. The `MultiTermIndex` reads these two files to build a hash table of user and their corresponding term index.