### PR TITLE
feat(index): batch invalidation writes for improved performance

### DIFF
--- a/rs/index/src/collection/core.rs
+++ b/rs/index/src/collection/core.rs
@@ -958,6 +958,12 @@ impl<Q: Quantizer + Clone + Send + Sync + 'static> Collection<Q> {
             }
             *pending_segment_write = None;
 
+            // Flush any invalidations that occurred during the flush (deletions above)
+            // to disk immediately as per design decision
+            if let BoxedImmutableSegment::FinalizedSegment(ref seg) = segment {
+                seg.write().await.flush_invalidations().await?;
+            }
+
             // Add segments while holding write lock to prevent insertions/invalidations
             self.add_segments(
                 vec![name_for_new_segment.clone()],

--- a/rs/index/src/multi_spann/reader.rs
+++ b/rs/index/src/multi_spann/reader.rs
@@ -117,6 +117,7 @@ mod tests {
         Ok(())
     }
 
+    /// Tests reading a multi-user SPANN index with Product Quantization.
     #[tokio::test]
     async fn test_multi_spann_reader_pq() -> Result<()> {
         let temp_dir = tempdir::TempDir::new("test_multi_spann_reader_pq")?;
@@ -163,6 +164,7 @@ mod tests {
         Ok(())
     }
 
+    /// Tests reading a multi-user SPANN index asynchronously.
     #[tokio::test]
     async fn test_multi_spann_reader_async() -> Result<()> {
         let temp_dir = tempdir::TempDir::new("test_multi_spann_reader_async")?;


### PR DESCRIPTION
Change invalidation persistence strategy from immediate disk writes to in-memory buffering with periodic flushing. This reduces I/O overhead when processing document deletions.

Key changes:

MultiSpannIndex:
- `invalidate()` and `invalidate_batch()` now only update in-memory state
- Add `flush_invalidations()` to persist buffered invalidations to disk
- Track pending invalidations in `DashMap<u128, HashSet<u128>>`

MutableSegment:
- Buffer invalidations in `DashMap` during `invalidate()` calls
- Write all pending invalidations to disk during `build()` via `InvalidatedIdsStorage`

ImmutableSegment:
- Add `pending_invalidations: RwLock<HashMap<u128, HashSet<u128>>>`
- Add `flush_invalidations()` method called during segment operations
- `remove()` now buffers instead of immediately persisting

Collection:
- Call `flush_invalidations()` on finalized segments during flush

io_uring improvements (uring_engine.rs, uring_file.rs):
- Fix buffer pinning: use `Pin<Vec<u8>>` instead of `Pin<Box<Vec<u8>>>`
- Replace `std::sync::Mutex` with `tokio::sync::Mutex` for async safety
- Add explicit Send/Sync impls for UringFile
- Fix Clippy warning: use `for` loop instead of `while let`

This design batches disk writes for deletions, reducing I/O overhead while maintaining consistency by flushing during segment build/flush operations.